### PR TITLE
Rm assertion

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <div align="center">
-  <img src="https://github.com/hudson-and-thames/mlfinlab/blob/master/.github/logo/hudson_and_thames_logo.png" height="300"><br>
+  <img src="https://raw.githubusercontent.com/hudson-and-thames/mlfinlab/master/.github/logo/hudson_and_thames_logo.png" height="300"><br>
 </div>
 
 -----------------
@@ -91,10 +91,8 @@ On your local machine open the terminal and cd into the working dir.
 
 * **Ashutosh Singh** - [LinkedIn](https://www.linkedin.com/in/ashusinghpenn/)
 * **Jacques Joubert** - [LinkedIn](https://www.linkedin.com/in/jacquesjoubert/)
-
-## Core Contributors
-
 * **Oleksandr Proskurin** - [LinkedIn](https://www.linkedin.com/in/proskurinolexandr/)
+
 
 ## Additional Research Repo
 BlackArbsCEO has a great repo based on de Prado's research. It covers many of the questions at the back of every chapter and was the first source on Github to do so. It has also been a good source of inspiration for our research. 

--- a/mlfinlab/data_structures/base_bars.py
+++ b/mlfinlab/data_structures/base_bars.py
@@ -105,10 +105,8 @@ class BaseBars(ABC):
         :param test_batch: (DataFrame) the first row of the dataset.
         """
         assert test_batch.shape[1] == 3, 'Must have only 3 columns in csv: date_time, price, & volume.'
-        assert isinstance(test_batch.iloc[0, 1],
-                          float), 'price column in csv not float.'
-        assert isinstance(test_batch.iloc[0, 2],
-                          np.int64), 'volume column in csv not int.'
+        assert isinstance(test_batch.iloc[0, 1], float), 'price column in csv not float.'
+        assert not isinstance(test_batch.iloc[0, 2], str), 'volume column in csv not int or float.'
 
         try:
             pd.to_datetime(test_batch.iloc[0, 0])

--- a/mlfinlab/tests/test_imbalance_data_structures.py
+++ b/mlfinlab/tests/test_imbalance_data_structures.py
@@ -144,7 +144,7 @@ class TestDataStructures(unittest.TestCase):
         """
         wrong_date = ['2019-41-30', 200.00, np.int64(5)]
         wrong_price = ['2019-01-30', 'asd', np.int64(5)]
-        wrong_volume = ['2019-01-30', 200.00, 1.5]
+        wrong_volume = ['2019-01-30', 200.00, '1.5']
         too_many_cols = ['2019-01-30', 200.00,
                          np.int64(5), 'Limit order', 'B23']
 

--- a/mlfinlab/tests/test_run_data_structures.py
+++ b/mlfinlab/tests/test_run_data_structures.py
@@ -145,7 +145,7 @@ class TestDataStructures(unittest.TestCase):
         """
         wrong_date = ['2019-41-30', 200.00, np.int64(5)]
         wrong_price = ['2019-01-30', 'asd', np.int64(5)]
-        wrong_volume = ['2019-01-30', 200.00, 1.5]
+        wrong_volume = ['2019-01-30', 200.00, '1.5']
         too_many_cols = ['2019-01-30', 200.00,
                          np.int64(5), 'Limit order', 'B23']
 

--- a/mlfinlab/tests/test_standard_data_structures.py
+++ b/mlfinlab/tests/test_standard_data_structures.py
@@ -127,7 +127,7 @@ class TestDataStructures(unittest.TestCase):
         """
         wrong_date = ['2019-41-30', 200.00, np.int64(5)]
         wrong_price = ['2019-01-30', 'asd', np.int64(5)]
-        wrong_volume = ['2019-01-30', 200.00, 1.5]
+        wrong_volume = ['2019-01-30', 200.00, '1.5']
         too_many_cols = ['2019-01-30', 200.00, np.int64(5), 'Limit order', 'B23']
 
         # pylint: disable=protected-access


### PR DESCRIPTION
Removed assertion that forced the data to have a volume that was of type int. There are examples when the volume will be a float such as in FX and cryptos. 