### PR TITLE
Bugfix betsize budget div zero

### DIFF
--- a/mlfinlab/bet_sizing/bet_sizing.py
+++ b/mlfinlab/bet_sizing/bet_sizing.py
@@ -91,9 +91,10 @@ def bet_size_budget(events_t1, sides):
      active long and short bets, as well as the bet size, in additional columns.
     """
     events_1 = get_concurrent_sides(events_t1, sides)
-    avg_active_long = events_1['active_long'] / events_1['active_long'].max()
-    avg_active_short = events_1['active_short'] / events_1['active_short'].max()
-    events_1['bet_size'] = avg_active_long - avg_active_short
+    active_long_max, active_short_max = events_1['active_long'].max(), events_1['active_short'].max()
+    frac_active_long = events_1['active_long'] / active_long_max if active_long_max > 0 else 0
+    frac_active_short = events_1['active_short'] / active_short_max if active_short_max > 0 else 0
+    events_1['bet_size'] = frac_active_long - frac_active_short
 
     return events_1
 


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # 135 bet_size_budget does not handle zero active bets

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Unit test added to test_bet_sizing.py with an all-long strategy; number of short bets is zero, thus maximum number of short bets is zero, causing a divide-by-zero if not handled.

**Test Configuration**:
* Ubuntu 18.04 LTS
* VIM, tested from command line


# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
