### PR TITLE
Add custom function to cross-validation/feat importance instead of str

### DIFF
--- a/mlfinlab/cross_validation/cross_validation.py
+++ b/mlfinlab/cross_validation/cross_validation.py
@@ -121,14 +121,14 @@ def ml_cross_val_score(
     .. code-block:: python
 
         cv_gen = PurgedKFold(n_splits=n_splits, samples_info_sets=samples_info_sets, pct_embargo=pct_embargo)
-        scores_array = ml_cross_val_score(classifier, X, y, cv_gen, sample_weight=None, scoring='neg_log_loss')
+        scores_array = ml_cross_val_score(classifier, X, y, cv_gen, sample_weight=None, scoring=accuracy_score)
 
     :param classifier: A sk-learn Classifier object instance.
     :param X: The dataset of records to evaluate.
     :param y: The labels corresponding to the X dataset.
     :param cv_gen: Cross Validation generator object instance.
     :param sample_weight: A numpy array of weights for each record in the dataset.
-    :param scoring: A metric scoring, can be custom sklearn metric
+    :param scoring: A metric scoring, can be custom sklearn metric.
     :return: The computed score as a numpy array.
     """
 

--- a/mlfinlab/cross_validation/cross_validation.py
+++ b/mlfinlab/cross_validation/cross_validation.py
@@ -2,10 +2,11 @@
 Implements the book chapter 7 on Cross Validation for financial data.
 """
 
+from typing import Callable
 import pandas as pd
 import numpy as np
 
-from sklearn.metrics import log_loss, accuracy_score, f1_score, precision_score, recall_score, roc_auc_score
+from sklearn.metrics import log_loss
 from sklearn.model_selection import KFold
 from sklearn.base import ClassifierMixin
 from sklearn.model_selection import BaseCrossValidator
@@ -103,8 +104,9 @@ def ml_cross_val_score(
         y: pd.Series,
         cv_gen: BaseCrossValidator,
         sample_weight: np.ndarray = None,
-        scoring: str = 'neg_log_loss'):
+        scoring: Callable[[np.array, np.array], float] = log_loss):
     # pylint: disable=invalid-name
+    # pylint: disable=comparison-with-callable
     """
     Snippet 7.4, page 110, Using the PurgedKFold Class.
     Function to run a cross-validation evaluation of the using sample weights and a custom CV generator.
@@ -126,17 +128,9 @@ def ml_cross_val_score(
     :param y: The labels corresponding to the X dataset.
     :param cv_gen: Cross Validation generator object instance.
     :param sample_weight: A numpy array of weights for each record in the dataset.
-    :param scoring: A metric name to use for scoring; currently supports `neg_log_loss`, `accuracy`, `f1`, `precision`,
-        `recall`, and `roc_auc`.
+    :param scoring: A metric scoring, can be custom sklearn metric
     :return: The computed score as a numpy array.
     """
-    # Define scoring metrics
-    scoring_func_dict = {'neg_log_loss': log_loss, 'accuracy': accuracy_score, 'f1': f1_score,
-                         'precision': precision_score, 'recall': recall_score, 'roc_auc': roc_auc_score}
-    try:
-        scoring_func = scoring_func_dict[scoring]
-    except KeyError:
-        raise ValueError('Wrong scoring method. Select from: neg_log_loss, accuracy, f1, precision, recall, roc_auc')
 
     # If no sample_weight then broadcast a value of 1 to all samples (full weight).
     if sample_weight is None:
@@ -146,11 +140,11 @@ def ml_cross_val_score(
     ret_scores = []
     for train, test in cv_gen.split(X=X, y=y):
         fit = classifier.fit(X=X.iloc[train, :], y=y.iloc[train], sample_weight=sample_weight[train])
-        if scoring == 'neg_log_loss':
+        if scoring == log_loss:
             prob = fit.predict_proba(X.iloc[test, :])
-            score = -1 * scoring_func(y.iloc[test], prob, sample_weight=sample_weight[test], labels=classifier.classes_)
+            score = -1 * scoring(y.iloc[test], prob, sample_weight=sample_weight[test], labels=classifier.classes_)
         else:
             pred = fit.predict(X.iloc[test, :])
-            score = scoring_func(y.iloc[test], pred, sample_weight=sample_weight[test])
+            score = scoring(y.iloc[test], pred, sample_weight=sample_weight[test])
         ret_scores.append(score)
     return np.array(ret_scores)

--- a/mlfinlab/feature_importance/importance.py
+++ b/mlfinlab/feature_importance/importance.py
@@ -4,13 +4,14 @@ Module which implements feature importance algorithms described in Chapter 8
 
 import pandas as pd
 import numpy as np
-from sklearn.metrics import log_loss, accuracy_score, precision_score, f1_score, recall_score, roc_auc_score
+from sklearn.metrics import log_loss
 import matplotlib.pyplot as plt
 from mlfinlab.cross_validation.cross_validation import ml_cross_val_score
 
 
 # pylint: disable=invalid-name
 # pylint: disable=invalid-unary-operand-type
+# pylint: disable=comparison-with-callable
 
 def feature_importance_mean_decrease_impurity(clf, feature_names):
     """
@@ -34,7 +35,7 @@ def feature_importance_mean_decrease_impurity(clf, feature_names):
     return imp
 
 
-def feature_importance_mean_decrease_accuracy(clf, X, y, cv_gen, sample_weight=None, scoring='neg_log_loss'):
+def feature_importance_mean_decrease_accuracy(clf, X, y, cv_gen, sample_weight=None, scoring=log_loss):
     """
     Snippet 8.3, page 116-117. MDA Feature Importance
 
@@ -45,19 +46,9 @@ def feature_importance_mean_decrease_accuracy(clf, X, y, cv_gen, sample_weight=N
     :param y: (pd.DataFrame, np.array): train set labels
     :param cv_gen: (cross_validation.PurgedKFold): cross-validation object
     :param sample_weight: (np.array): sample weights, if None equal to ones
-    :param scoring: (str): scoring function used to determine importance, either 'neg_log_loss' or 'accuracy'
+    :param scoring: (function): scoring function used to determine importance
     :return: (pd.DataFrame): mean and std feature importance
     """
-    # Feature importance based on OOS score reduction
-    scoring_func_dict = {'neg_log_loss': log_loss, 'accuracy': accuracy_score, 'f1': f1_score,
-                         'precision': precision_score, 'recall': recall_score, 'roc_auc': roc_auc_score}
-    try:
-        scoring_func_dict[scoring]
-    except KeyError:
-        raise ValueError(
-            'Invalid choice of scoring method. Possible scoring methods:{}.'.format(list(scoring_func_dict.keys())))
-
-    scoring_func = scoring_func_dict[scoring]
 
     if sample_weight is None:
         sample_weight = np.ones((X.shape[0],))
@@ -69,28 +60,28 @@ def feature_importance_mean_decrease_accuracy(clf, X, y, cv_gen, sample_weight=N
         pred = fit.predict(X.iloc[test, :])
 
         # Get overall metrics value on out-of-sample fold
-        if scoring == 'neg_log_loss':
+        if scoring == log_loss:
             prob = fit.predict_proba(X.iloc[test, :])
-            fold_metrics_values.loc[i] = -scoring_func(y.iloc[test], prob, sample_weight=sample_weight[test],
-                                                       labels=clf.classes_)
+            fold_metrics_values.loc[i] = -scoring(y.iloc[test], prob, sample_weight=sample_weight[test],
+                                                  labels=clf.classes_)
         else:
-            fold_metrics_values.loc[i] = scoring_func(y.iloc[test], pred, sample_weight=sample_weight[test])
+            fold_metrics_values.loc[i] = scoring(y.iloc[test], pred, sample_weight=sample_weight[test])
 
         # Get feature specific metric on out-of-sample fold
         for j in X.columns:
             X1_ = X.iloc[test, :].copy(deep=True)
             np.random.shuffle(X1_[j].values)  # Permutation of a single column
-            if scoring == 'neg_log_loss':
+            if scoring == log_loss:
                 prob = fit.predict_proba(X1_)
-                features_metrics_values.loc[i, j] = -scoring_func(y.iloc[test], prob, sample_weight=sample_weight[test],
-                                                                  labels=clf.classes_)
+                features_metrics_values.loc[i, j] = -scoring(y.iloc[test], prob, sample_weight=sample_weight[test],
+                                                             labels=clf.classes_)
             else:
                 pred = fit.predict(X1_)
-                features_metrics_values.loc[i, j] = scoring_func(y.iloc[test], pred,
-                                                                 sample_weight=sample_weight[test])
+                features_metrics_values.loc[i, j] = scoring(y.iloc[test], pred,
+                                                            sample_weight=sample_weight[test])
 
     imp = (-features_metrics_values).add(fold_metrics_values, axis=0)
-    if scoring == 'neg_log_loss':
+    if scoring == log_loss:
         imp = imp / -features_metrics_values
     else:
         imp = imp / (1. - features_metrics_values)
@@ -99,7 +90,7 @@ def feature_importance_mean_decrease_accuracy(clf, X, y, cv_gen, sample_weight=N
     return imp
 
 
-def feature_importance_sfi(clf, X, y, cv_gen, sample_weight=None, scoring='neg_log_loss'):
+def feature_importance_sfi(clf, X, y, cv_gen, sample_weight=None, scoring=log_loss):
     """
     Snippet 8.4, page 118. Implementation of SFI
 
@@ -110,7 +101,7 @@ def feature_importance_sfi(clf, X, y, cv_gen, sample_weight=None, scoring='neg_l
     :param y: (pd.DataFrame, np.array): train set labels
     :param cv_gen: (cross_validation.PurgedKFold): cross-validation object
     :param sample_weight: (np.array): sample weights, if None equal to ones
-    :param scoring: (str): scoring function used to determine importance
+    :param scoring: (function): scoring function used to determine importance
     :return: (pd.DataFrame): mean and std feature importance
     """
     feature_names = X.columns

--- a/mlfinlab/tests/test_cross_validation.py
+++ b/mlfinlab/tests/test_cross_validation.py
@@ -7,6 +7,7 @@ import pandas as pd
 import numpy as np
 from sklearn.tree import DecisionTreeClassifier
 from sklearn.model_selection import TimeSeriesSplit
+from sklearn.metrics import log_loss, accuracy_score
 
 from mlfinlab.cross_validation.cross_validation import (
     ml_get_train_times,
@@ -293,27 +294,6 @@ class TestCrossValidation(unittest.TestCase):
         decision_tree = DecisionTreeClassifier(random_state=0)
         return info_sets, records, labels, sample_weights, decision_tree
 
-    def test_ml_cross_val_score_00_exception(self):
-        """
-        Test the ml_cross_val_score function with an artificial dataset. In this case we give it the wrong scoring
-        method - jaccard_score.
-        """
-        info_sets, records, labels, sample_weights, decision_tree = self._test_ml_cross_val_score__data()
-        cv_gen = PurgedKFold(samples_info_sets=info_sets, n_splits=3, pct_embargo=0.01)
-        try:
-            ml_cross_val_score(
-                classifier=decision_tree,
-                X=records,
-                y=labels,
-                sample_weight=sample_weights.values,
-                scoring='jaccard_score',
-                cv_gen=cv_gen,
-            )
-        except ValueError:
-            pass
-        else:
-            self.fail("ValueError not raised")
-
     def test_ml_cross_val_score_01_accuracy(self):
         """
         Test the ml_cross_val_score function with an artificial dataset.
@@ -325,7 +305,7 @@ class TestCrossValidation(unittest.TestCase):
             X=records,
             y=labels,
             sample_weight=sample_weights.values,
-            scoring='accuracy',
+            scoring=accuracy_score,
             cv_gen=cv_gen,
         )
         self.log(f"score1= {scores}")
@@ -347,7 +327,7 @@ class TestCrossValidation(unittest.TestCase):
             X=records,
             y=labels,
             sample_weight=sample_weights.values,
-            scoring='neg_log_loss',
+            scoring=log_loss,
             cv_gen=cv_gen,
         )
         self.log(f"scores= {scores}")
@@ -368,7 +348,7 @@ class TestCrossValidation(unittest.TestCase):
             X=records,
             y=labels,
             sample_weight=sample_weights.values,
-            scoring='neg_log_loss',
+            scoring=log_loss,
             cv_gen=TimeSeriesSplit(max_train_size=None, n_splits=3),
         )
         self.log(f"scores= {scores}")
@@ -391,7 +371,7 @@ class TestCrossValidation(unittest.TestCase):
             X=records,
             y=labels,
             sample_weight=None,
-            scoring='accuracy',
+            scoring=accuracy_score,
             cv_gen=cv_gen,
         )
         self.log(f"score1= {scores}")

--- a/mlfinlab/tests/test_feature_importance.py
+++ b/mlfinlab/tests/test_feature_importance.py
@@ -10,6 +10,7 @@ import pandas as pd
 
 from sklearn.ensemble import RandomForestClassifier
 from sklearn.model_selection import train_test_split
+from sklearn.metrics import f1_score, accuracy_score
 
 from mlfinlab.util.utils import get_daily_vol
 from mlfinlab.filters.filters import cusum_filter
@@ -179,13 +180,13 @@ class TestFeatureImportance(unittest.TestCase):
                                                                           sample_weight=np.ones(
                                                                               (self.X_train.shape[0],)))
         mda_feat_imp_f1 = feature_importance_mean_decrease_accuracy(sb_clf, self.X_train, self.y_train_clf,
-                                                                    cv_gen, scoring='f1')
+                                                                    cv_gen, scoring=f1_score)
         # SFI feature importance
         sfi_feat_imp_log_loss = feature_importance_sfi(sb_clf, self.X_train[self.X_train.columns[:5]], self.y_train_clf,
                                                        cv_gen=cv_gen, sample_weight=np.ones((self.X_train.shape[0],)))
         sfi_feat_imp_f1 = feature_importance_sfi(sb_clf, self.X_train[self.X_train.columns[:5]], self.y_train_clf,
                                                  cv_gen=cv_gen,
-                                                 scoring='f1')  # Take only 5 features for faster test run
+                                                 scoring=f1_score)  # Take only 5 features for faster test run
 
         # MDI assertions
         self.assertTrue(mdi_feat_imp['mean'].sum() == 1)
@@ -220,7 +221,7 @@ class TestFeatureImportance(unittest.TestCase):
 
         sb_clf, cv_gen = self._prepare_clf_data_set(oob_score=True)
         oos_score = ml_cross_val_score(sb_clf, self.X_train, self.y_train_clf, cv_gen=cv_gen, sample_weight=None,
-                                       scoring='accuracy').mean()
+                                       scoring=accuracy_score).mean()
 
         sb_clf.fit(self.X_train, self.y_train_clf)
 
@@ -248,17 +249,3 @@ class TestFeatureImportance(unittest.TestCase):
 
         cv_gen = PurgedKFold(n_splits=4, samples_info_sets=self.samples_info_sets)
         return sb_clf, cv_gen
-
-    def test_raise_value_error(self):
-        """
-        Test ValueError raise in MDA, SFI
-        """
-        sb_clf, cv_gen = self._prepare_clf_data_set(oob_score=False)
-
-        with self.assertRaises(ValueError):
-            feature_importance_mean_decrease_accuracy(sb_clf, self.X_train, self.y_train_clf,
-                                                      cv_gen, sample_weight=np.ones((self.X_train.shape[0],)),
-                                                      scoring='roc')
-        with self.assertRaises(ValueError):
-            feature_importance_sfi(sb_clf, self.X_train[self.X_train.columns[:5]], self.y_train_clf,
-                                   cv_gen=cv_gen, sample_weight=np.ones((self.X_train.shape[0],)), scoring='roc')


### PR DESCRIPTION
# Description

Sometimes (if not usually) user wants to path custom scoring function which represents his domain fitness function. For example custom f-beta score can be passed. For that purpose cross-val/feature importance were reimplemented so that custom function is passed

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- test_feature_importance.py
- test_cross_validation.py

**Test Configuration**:
*Mac OS 
* Atom


# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
