### PR TITLE
Remove `matplotlib.use('Agg')` and set `resample_by=None`

### DIFF
--- a/mlfinlab/portfolio_optimization/hrp.py
+++ b/mlfinlab/portfolio_optimization/hrp.py
@@ -10,7 +10,6 @@ import pandas as pd
 from scipy.cluster.hierarchy import dendrogram, linkage
 from scipy.spatial.distance import squareform
 from sklearn.covariance import OAS
-import matplotlib
 
 
 class HierarchicalRiskParity:

--- a/mlfinlab/portfolio_optimization/hrp.py
+++ b/mlfinlab/portfolio_optimization/hrp.py
@@ -137,7 +137,8 @@ class HierarchicalRiskParity:
         :return: (pd.Dataframe) stock returns
         '''
 
-        asset_prices = asset_prices.resample(resample_by).last()
+        if resample_by is not None:
+            asset_prices = asset_prices.resample(resample_by).last()
         asset_returns = asset_prices.pct_change()
         asset_returns = asset_returns.dropna(how='all')
         return asset_returns
@@ -173,14 +174,14 @@ class HierarchicalRiskParity:
         corr = pd.DataFrame(corr, index=covariance.columns, columns=covariance.columns)
         return corr
 
-    def allocate(self, asset_prices, resample_by='B', use_shrinkage=False):
+    def allocate(self, asset_prices, resample_by=None, use_shrinkage=False):
         '''
         Calculate asset allocations using HRP algorithm
 
         :param asset_prices: (pd.Dataframe) a dataframe of historical asset prices (daily close)
                                             indexed by date
         :param resample_by: (str) specifies how to resample the prices - weekly, daily, monthly etc.. Defaults to
-                                          'B' meaning daily business days which is equivalent to no resampling
+                                          None which is equivalent to no resampling
         :param use_shrinkage: (Boolean) specifies whether to shrink the covariances
         '''
 

--- a/mlfinlab/portfolio_optimization/hrp.py
+++ b/mlfinlab/portfolio_optimization/hrp.py
@@ -12,8 +12,6 @@ from scipy.spatial.distance import squareform
 from sklearn.covariance import OAS
 import matplotlib
 
-matplotlib.use('Agg')
-
 
 class HierarchicalRiskParity:
     '''


### PR DESCRIPTION
# Description

This PR addresses 2 problems:
- `matplotlib.use('Agg')` in `portfolio_optimization/hrp.py` effects the global settings.
  After importing `hrp.py` module, one can not show plots in interactive environments like `Jupyterlab`.
- `HierarchicalRiskParity.allocation` has default value `resample_by='B'`, which does resampling.
  But the doc says `Defaults to 'B' meaning daily business days which is equivalent to no resampling`, so I think that's not what you want. And there is no way to calculate_returns without resampling, thus I set `resample_by=None` and added an `if-else` statement.

## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
