### PR TITLE
[IN-PROGRESS] Add some enhancements to portfolio_optimisation module

### DIFF
--- a/mlfinlab/portfolio_optimization/cla.py
+++ b/mlfinlab/portfolio_optimization/cla.py
@@ -385,19 +385,19 @@ class CLA:
                     lambda_out, i_out = lambda_i, i
         return lambda_out, i_out
 
-    def _initialise(self, asset_prices, mean_asset_returns, returns_matrix, resample_by):
+    def _initialise(self, asset_prices, expected_asset_returns, returns_matrix, resample_by):
         '''
         Initialise covariances, upper-counds, lower-bounds and storage buffers
 
         :param asset_prices: (pd.Dataframe) dataframe of asset prices indexed by date
-        :param mean_asset_returns: (pd.Dataframe) a list of mean stock returns (mu)
+        :param expected_asset_returns: (pd.Dataframe) a list of mean stock returns (mu)
         :param returns_matrix: (pd.Dataframe) user supplied dataframe of asset returns indexed by date
         :param resample_by: (str) specifies how to resample the prices - weekly, daily, monthly etc.. Defaults to
                                   'B' meaning daily business days which is equivalent to no resampling
         '''
 
         # Initial checks
-        if asset_prices is None and (mean_asset_returns is None or returns_matrix is None):
+        if asset_prices is None and (expected_asset_returns is None or returns_matrix is None):
             raise ValueError("Either supply your own asset returns matrix or pass the asset prices as input")
         if asset_prices is not None and not isinstance(asset_prices, pd.DataFrame):
             raise ValueError("Asset prices matrix must be a dataframe")
@@ -409,8 +409,8 @@ class CLA:
             raise ValueError("Asset returns dataframe must be indexed by date.")
 
         # Calculate the returns if the user does not supply a returns matrix
-        self.expected_returns = mean_asset_returns
-        if mean_asset_returns is None:
+        self.expected_returns = expected_asset_returns
+        if expected_asset_returns is None:
             if self.calculate_returns == "mean":
                 self.expected_returns = self._calculate_mean_historical_returns(asset_prices=asset_prices,
                                                                                 resample_by=resample_by)
@@ -498,7 +498,7 @@ class CLA:
 
     def allocate(self,
                  asset_prices=None,
-                 mean_historical_asset_returns=None,
+                 expected_asset_returns=None,
                  returns_matrix=None,
                  solution="cla_turning_points",
                  resample_by=None):
@@ -507,7 +507,7 @@ class CLA:
         Calculate the portfolio asset allocations using the method specified.
 
         :param asset_prices: (pd.Dataframe) a dataframe of historical asset prices (adj closed)
-        :param mean_historical_asset_returns: (list) a list of mean stock returns (mu)
+        :param expected_asset_returns: (list) a list of mean stock returns (mu)
         :param returns_matrix: (pd.Dataframe) user supplied dataframe of asset returns indexed by date
         :param solution: (str) specify the type of solution to compute. Options are: cla_turning_points, max_sharpe,
                                min_volatility, efficient_frontier
@@ -518,7 +518,7 @@ class CLA:
         # Some initial steps before the algorithm runs
         self._initialise(asset_prices=asset_prices,
                          resample_by=resample_by,
-                         mean_asset_returns=mean_historical_asset_returns,
+                         expected_asset_returns=expected_asset_returns,
                          returns_matrix=returns_matrix)
         assets = asset_prices.columns if asset_prices is not None else returns_matrix.columns
 

--- a/mlfinlab/portfolio_optimization/cla.py
+++ b/mlfinlab/portfolio_optimization/cla.py
@@ -401,7 +401,8 @@ class CLA:
             raise ValueError("Asset prices dataframe must be indexed by date.")
 
         # Resample the asset prices
-        asset_prices = asset_prices.resample(resample_by).last()
+        if resample_by:
+            asset_prices = asset_prices.resample(resample_by).last()
 
         # Calculate the expected returns
         if self.calculate_returns == "mean":
@@ -462,7 +463,7 @@ class CLA:
         returns = returns.ewm(span=span).mean().iloc[-1] * frequency
         return returns
 
-    def allocate(self, asset_prices, solution="cla_turning_points", resample_by="B"):
+    def allocate(self, asset_prices, solution="cla_turning_points", resample_by=None):
         # pylint: disable=consider-using-enumerate,too-many-locals,too-many-branches,too-many-statements
         '''
         Calculate the portfolio asset allocations using the method specified.
@@ -471,7 +472,7 @@ class CLA:
         :param solution: (str) specify the type of solution to compute. Options are: cla_turning_points, max_sharpe,
                                min_volatility, efficient_frontier
         :param resample_by: (str) specifies how to resample the prices - weekly, daily, monthly etc.. Defaults to
-                                  'B' meaning daily business days which is equivalent to no resampling
+                                  None for no resampling
         '''
 
         # Some initial steps before the algorithm runs

--- a/mlfinlab/portfolio_optimization/cla.py
+++ b/mlfinlab/portfolio_optimization/cla.py
@@ -386,6 +386,7 @@ class CLA:
         return lambda_out, i_out
 
     def _initialise(self, asset_prices, expected_asset_returns, returns_matrix, resample_by):
+        # pylint: disable=invalid-name, too-many-branches
         '''
         Initialise covariances, upper-counds, lower-bounds and storage buffers
 

--- a/mlfinlab/portfolio_optimization/cla.py
+++ b/mlfinlab/portfolio_optimization/cla.py
@@ -392,7 +392,8 @@ class CLA:
 
         :param asset_prices: (pd.Dataframe) dataframe of asset prices indexed by date
         :param expected_asset_returns: (pd.Dataframe) a list of mean stock returns (mu)
-        :param returns_matrix: (pd.Dataframe) user supplied dataframe of asset returns indexed by date
+        :param returns_matrix: (pd.Dataframe) user supplied dataframe of asset returns indexed by date. Used for
+                                              calculation of covariance matrix
         :param resample_by: (str) specifies how to resample the prices - weekly, daily, monthly etc.. Defaults to
                                   'B' meaning daily business days which is equivalent to no resampling
         '''

--- a/mlfinlab/portfolio_optimization/hrp.py
+++ b/mlfinlab/portfolio_optimization/hrp.py
@@ -200,7 +200,7 @@ class HierarchicalRiskParity:
 
         # Calculate the returns if the user does not supply a returns matrix
         if asset_returns is None:
-            asset_returns = self._calculate_returns(asset_prices, resample_by=resample_by)
+            asset_returns = self._calculate_returns(asset_prices=asset_prices, resample_by=resample_by)
 
         num_assets = asset_returns.shape[1]
         assets = asset_returns.columns

--- a/mlfinlab/portfolio_optimization/hrp.py
+++ b/mlfinlab/portfolio_optimization/hrp.py
@@ -10,7 +10,6 @@ import pandas as pd
 from scipy.cluster.hierarchy import dendrogram, linkage
 from scipy.spatial.distance import squareform
 from sklearn.covariance import OAS
-import matplotlib
 
 
 class HierarchicalRiskParity:

--- a/mlfinlab/portfolio_optimization/hrp.py
+++ b/mlfinlab/portfolio_optimization/hrp.py
@@ -174,51 +174,62 @@ class HierarchicalRiskParity:
         corr = pd.DataFrame(corr, index=covariance.columns, columns=covariance.columns)
         return corr
 
-    def allocate(self, asset_prices=None, asset_returns=None, resample_by=None, use_shrinkage=False):
+    def allocate(self,
+                 asset_names,
+                 asset_prices=None,
+                 asset_returns=None,
+                 covariance_matrix=None,
+                 resample_by=None,
+                 use_shrinkage=False):
         # pylint: disable=invalid-name, too-many-branches
         '''
         Calculate asset allocations using HRP algorithm
 
+        :param asset_names: (list) a list of strings containing the asset names
         :param asset_prices: (pd.Dataframe) a dataframe of historical asset prices (daily close)
                                             indexed by date
-        :param asset_returns: (pd.Dataframe) user supplied dataframe of asset returns indexed by date
+        :param asset_returns: (pd.Dataframe/numpy matrix) user supplied matrix of asset returns indexed by date
+        :param covariance_matrix: (pd.Dataframe/numpy matrix) user supplied covariance matrix of asset returns
         :param resample_by: (str) specifies how to resample the prices - weekly, daily, monthly etc.. Defaults to
                                   None for no resampling
         :param use_shrinkage: (Boolean) specifies whether to shrink the covariances
         '''
 
-        if asset_prices is None and asset_returns is None:
-            raise ValueError("Either supply your own asset returns matrix or pass the asset prices as input")
-        if asset_prices is not None and not isinstance(asset_prices, pd.DataFrame):
-            raise ValueError("Asset prices matrix must be a dataframe")
-        if asset_prices is not None and not isinstance(asset_prices.index, pd.DatetimeIndex):
-            raise ValueError("Asset prices dataframe must be indexed by date.")
-        if asset_returns is not None and not isinstance(asset_returns, pd.DataFrame):
-            raise ValueError("Asset returns matrix must be a dataframe")
-        if asset_returns is not None and not isinstance(asset_returns.index, pd.DatetimeIndex):
-            raise ValueError("Asset returns dataframe must be indexed by date.")
+        if asset_prices is None and asset_returns is None and covariance_matrix is None:
+            raise ValueError("You need to supply either raw prices or returns or a covariance matrix of asset returns")
 
-        # Calculate the returns if the user does not supply a returns matrix
-        if asset_returns is None:
+        if asset_prices is not None:
+            if not isinstance(asset_prices, pd.DataFrame):
+                raise ValueError("Asset prices matrix must be a dataframe")
+            if not isinstance(asset_prices.index, pd.DatetimeIndex):
+                raise ValueError("Asset prices dataframe must be indexed by date.")
+
+        # Calculate the returns if the user does not supply a returns dataframe
+        if asset_returns is None and covariance_matrix is None:
             asset_returns = self._calculate_returns(asset_prices=asset_prices, resample_by=resample_by)
+        asset_returns = pd.DataFrame(asset_returns, columns=asset_names)
 
-        num_assets = asset_returns.shape[1]
-        assets = asset_returns.columns
+        # Calculate covariance of returns or use the user specified covariance matrix
+        if covariance_matrix is None:
+            covariance_matrix = asset_returns.cov()
+        cov = pd.DataFrame(covariance_matrix, index=asset_names, columns=asset_names)
 
-        # Covariance and correlation
-        cov = asset_returns.cov()
+        # Shrink covariance
         if use_shrinkage:
             cov = self._shrink_covariance(covariance=cov)
+
+        # Calculate correlation from covariance matrix
         corr = self._cov2corr(covariance=cov)
 
         # Step-1: Tree Clustering
         distances, self.clusters = self._tree_clustering(correlation=corr)
 
         # Step-2: Quasi Diagnalization
+        num_assets = len(asset_names)
         self.ordered_indices = self._quasi_diagnalization(num_assets, 2 * num_assets - 2)
-        self.seriated_distances, self.seriated_correlations = self._get_seriated_matrix(assets=assets,
+        self.seriated_distances, self.seriated_correlations = self._get_seriated_matrix(assets=asset_names,
                                                                                         distances=distances,
                                                                                         correlations=corr)
 
         # Step-3: Recursive Bisection
-        self._recursive_bisection(covariances=cov, assets=assets)
+        self._recursive_bisection(covariances=cov, assets=asset_names)

--- a/mlfinlab/portfolio_optimization/hrp.py
+++ b/mlfinlab/portfolio_optimization/hrp.py
@@ -174,24 +174,32 @@ class HierarchicalRiskParity:
         corr = pd.DataFrame(corr, index=covariance.columns, columns=covariance.columns)
         return corr
 
-    def allocate(self, asset_prices, resample_by=None, use_shrinkage=False):
+    def allocate(self, asset_prices=None, asset_returns=None, resample_by=None, use_shrinkage=False):
         '''
         Calculate asset allocations using HRP algorithm
 
         :param asset_prices: (pd.Dataframe) a dataframe of historical asset prices (daily close)
                                             indexed by date
+        :param asset_returns: (pd.Dataframe) user supplied dataframe of asset returns indexed by date
         :param resample_by: (str) specifies how to resample the prices - weekly, daily, monthly etc.. Defaults to
                                   None for no resampling
         :param use_shrinkage: (Boolean) specifies whether to shrink the covariances
         '''
 
-        if not isinstance(asset_prices, pd.DataFrame):
+        if asset_prices is None and asset_returns is None:
+            raise ValueError("Either supply your own asset returns matrix or pass the asset prices as input")
+        if asset_prices is not None and not isinstance(asset_prices, pd.DataFrame):
             raise ValueError("Asset prices matrix must be a dataframe")
-        if not isinstance(asset_prices.index, pd.DatetimeIndex):
+        if asset_prices is not None and not isinstance(asset_prices.index, pd.DatetimeIndex):
             raise ValueError("Asset prices dataframe must be indexed by date.")
+        if asset_returns is not None and not isinstance(asset_returns, pd.DataFrame):
+            raise ValueError("Asset returns matrix must be a dataframe")
+        if asset_returns is not None and not isinstance(asset_returns.index, pd.DatetimeIndex):
+            raise ValueError("Asset returns dataframe must be indexed by date.")
 
-        # Calculate the returns
-        asset_returns = self._calculate_returns(asset_prices, resample_by=resample_by)
+        # Calculate the returns if the user does not supply a returns matrix
+        if asset_returns is None:
+            asset_returns = self._calculate_returns(asset_prices, resample_by=resample_by)
 
         num_assets = asset_returns.shape[1]
         assets = asset_returns.columns

--- a/mlfinlab/portfolio_optimization/hrp.py
+++ b/mlfinlab/portfolio_optimization/hrp.py
@@ -175,6 +175,7 @@ class HierarchicalRiskParity:
         return corr
 
     def allocate(self, asset_prices=None, asset_returns=None, resample_by=None, use_shrinkage=False):
+        # pylint: disable=invalid-name, too-many-branches
         '''
         Calculate asset allocations using HRP algorithm
 

--- a/mlfinlab/portfolio_optimization/hrp.py
+++ b/mlfinlab/portfolio_optimization/hrp.py
@@ -12,8 +12,6 @@ from scipy.spatial.distance import squareform
 from sklearn.covariance import OAS
 import matplotlib
 
-matplotlib.use('Agg')
-
 
 class HierarchicalRiskParity:
     '''
@@ -136,11 +134,12 @@ class HierarchicalRiskParity:
 
         :param asset_prices: (pd.Dataframe) a dataframe of historical asset prices (daily close)
         :param resample_by: (str) specifies how to resample the prices - weekly, daily, monthly etc.. Defaults to
-                                  'B' meaning daily business days which is equivalent to no resampling
+                                  None for no resampling
         :return: (pd.Dataframe) stock returns
         '''
 
-        asset_prices = asset_prices.resample(resample_by).last()
+        if resample_by:
+            asset_prices = asset_prices.resample(resample_by).last()
         asset_returns = asset_prices.pct_change()
         asset_returns = asset_returns.dropna(how='all')
         return asset_returns
@@ -176,14 +175,14 @@ class HierarchicalRiskParity:
         corr = pd.DataFrame(corr, index=covariance.columns, columns=covariance.columns)
         return corr
 
-    def allocate(self, asset_prices, resample_by='B', use_shrinkage=False):
+    def allocate(self, asset_prices, resample_by=None, use_shrinkage=False):
         '''
         Calculate asset allocations using HRP algorithm
 
         :param asset_prices: (pd.Dataframe) a dataframe of historical asset prices (daily close)
                                             indexed by date
         :param resample_by: (str) specifies how to resample the prices - weekly, daily, monthly etc.. Defaults to
-                                          'B' meaning daily business days which is equivalent to no resampling
+                                  None for no resampling
         :param use_shrinkage: (Boolean) specifies whether to shrink the covariances
         '''
 

--- a/mlfinlab/portfolio_optimization/mean_variance.py
+++ b/mlfinlab/portfolio_optimization/mean_variance.py
@@ -16,14 +16,14 @@ class MeanVarianceOptimisation:
     def __init__(self):
         self.weights = list()
 
-    def allocate(self, asset_prices, solution='inverse_variance', resample_by='B'):
+    def allocate(self, asset_prices, solution='inverse_variance', resample_by=None):
         '''
         Calculate the portfolio asset allocations using the method specified.
 
         :param asset_prices: (pd.Dataframe) a dataframe of historical asset prices (daily close)
         :param solution: (str) the type of solution/algorithm to use to calculate the weights
         :param resample_by: (str) specifies how to resample the prices - weekly, daily, monthly etc.. Defaults to
-                                  'B' meaning daily business days which is equivalent to no resampling
+                                  None for no resampling
         '''
 
         if not isinstance(asset_prices, pd.DataFrame):
@@ -51,11 +51,12 @@ class MeanVarianceOptimisation:
 
         :param asset_prices: (pd.Dataframe) a dataframe of historical asset prices (daily close)
         :param resample_by: (str) specifies how to resample the prices - weekly, daily, monthly etc.. Defaults to
-                                  'B' meaning daily business days which is equivalent to no resampling
+                                  None for no resampling
         :return: (pd.Dataframe) stock returns
         '''
 
-        asset_prices = asset_prices.resample(resample_by).last()
+        if resample_by:
+            asset_prices = asset_prices.resample(resample_by).last()
         asset_returns = asset_prices.pct_change()
         asset_returns = asset_returns.dropna(how='all')
         return asset_returns

--- a/mlfinlab/portfolio_optimization/mean_variance.py
+++ b/mlfinlab/portfolio_optimization/mean_variance.py
@@ -16,41 +16,50 @@ class MeanVarianceOptimisation:
     def __init__(self):
         self.weights = list()
 
-    def allocate(self, asset_prices=None, asset_returns=None, solution='inverse_variance', resample_by=None):
+    def allocate(self,
+                 asset_names,
+                 asset_prices=None,
+                 asset_returns=None,
+                 covariance_matrix=None,
+                 solution='inverse_variance',
+                 resample_by=None):
         # pylint: disable=invalid-name, too-many-branches
         '''
         Calculate the portfolio asset allocations using the method specified.
 
         :param asset_prices: (pd.Dataframe) a dataframe of historical asset prices (daily close)
-        :param asset_returns: (pd.Dataframe) user calculated dataframe of asset returns indexed by date
+        :param asset_returns: (pd.Dataframe/numpy matrix) user supplied matrix of asset returns indexed by date
+        :param covariance_matrix: (pd.Dataframe/numpy matrix) user supplied covariance matrix of asset returns
         :param solution: (str) the type of solution/algorithm to use to calculate the weights
         :param resample_by: (str) specifies how to resample the prices - weekly, daily, monthly etc.. Defaults to
                                   None for no resampling
         '''
 
-        if asset_prices is None and asset_returns is None:
-            raise ValueError("Either supply your own asset returns matrix or pass the asset prices as input")
-        if asset_prices is not None and not isinstance(asset_prices, pd.DataFrame):
-            raise ValueError("Asset prices matrix must be a dataframe")
-        if asset_prices is not None and not isinstance(asset_prices.index, pd.DatetimeIndex):
-            raise ValueError("Asset prices dataframe must be indexed by date.")
-        if asset_returns is not None and not isinstance(asset_returns, pd.DataFrame):
-            raise ValueError("Asset returns matrix must be a dataframe")
-        if asset_returns is not None and not isinstance(asset_returns.index, pd.DatetimeIndex):
-            raise ValueError("Asset returns dataframe must be indexed by date.")
+        if asset_prices is None and asset_returns is None and covariance_matrix is None:
+            raise ValueError("You need to supply either raw prices or returns or a covariance matrix of asset returns")
 
-        # Calculate the returns if the user does not supply a asset returns matrix
-        if asset_returns is None:
+        if asset_prices is not None:
+            if not isinstance(asset_prices, pd.DataFrame):
+                raise ValueError("Asset prices matrix must be a dataframe")
+            if not isinstance(asset_prices.index, pd.DatetimeIndex):
+                raise ValueError("Asset prices dataframe must be indexed by date.")
+
+        # Calculate the returns if the user does not supply a returns dataframe
+        if asset_returns is None and covariance_matrix is None:
             asset_returns = self._calculate_returns(asset_prices=asset_prices, resample_by=resample_by)
-        assets = asset_returns.columns
+        asset_returns = pd.DataFrame(asset_returns, columns=asset_names)
+
+        # Calculate covariance of returns or use the user specified covariance matrix
+        if covariance_matrix is None:
+            covariance_matrix = asset_returns.cov()
+        cov = pd.DataFrame(covariance_matrix, index=asset_names, columns=asset_names)
 
         if solution == 'inverse_variance':
-            cov = asset_returns.cov()
             self.weights = self._inverse_variance(covariance=cov)
         else:
             raise ValueError("Unknown solution string specified. Supported solutions - inverse_variance.")
         self.weights = pd.DataFrame(self.weights)
-        self.weights.index = assets
+        self.weights.index = asset_names
         self.weights = self.weights.T
 
     @staticmethod

--- a/mlfinlab/portfolio_optimization/mean_variance.py
+++ b/mlfinlab/portfolio_optimization/mean_variance.py
@@ -16,24 +16,32 @@ class MeanVarianceOptimisation:
     def __init__(self):
         self.weights = list()
 
-    def allocate(self, asset_prices, solution='inverse_variance', resample_by=None):
+    def allocate(self, asset_prices=None, asset_returns=None, solution='inverse_variance', resample_by=None):
         '''
         Calculate the portfolio asset allocations using the method specified.
 
         :param asset_prices: (pd.Dataframe) a dataframe of historical asset prices (daily close)
+        :param asset_returns: (pd.Dataframe) user calculated dataframe of asset returns indexed by date
         :param solution: (str) the type of solution/algorithm to use to calculate the weights
         :param resample_by: (str) specifies how to resample the prices - weekly, daily, monthly etc.. Defaults to
                                   None for no resampling
         '''
 
-        if not isinstance(asset_prices, pd.DataFrame):
+        if asset_prices is None and asset_returns is None:
+            raise ValueError("Either supply your own asset returns matrix or pass the asset prices as input")
+        if asset_prices is not None and not isinstance(asset_prices, pd.DataFrame):
             raise ValueError("Asset prices matrix must be a dataframe")
-        if not isinstance(asset_prices.index, pd.DatetimeIndex):
+        if asset_prices is not None and not isinstance(asset_prices.index, pd.DatetimeIndex):
             raise ValueError("Asset prices dataframe must be indexed by date.")
+        if asset_returns is not None and not isinstance(asset_returns, pd.DataFrame):
+            raise ValueError("Asset returns matrix must be a dataframe")
+        if asset_returns is not None and not isinstance(asset_returns.index, pd.DatetimeIndex):
+            raise ValueError("Asset returns dataframe must be indexed by date.")
 
-        # Calculate returns
-        asset_returns = self._calculate_returns(asset_prices, resample_by=resample_by)
-        assets = asset_prices.columns
+        # Calculate the returns if the user does not supply a asset returns matrix
+        if asset_returns is None:
+            asset_returns = self._calculate_returns(asset_prices, resample_by=resample_by)
+        assets = asset_returns.columns
 
         if solution == 'inverse_variance':
             cov = asset_returns.cov()

--- a/mlfinlab/portfolio_optimization/mean_variance.py
+++ b/mlfinlab/portfolio_optimization/mean_variance.py
@@ -17,6 +17,7 @@ class MeanVarianceOptimisation:
         self.weights = list()
 
     def allocate(self, asset_prices=None, asset_returns=None, solution='inverse_variance', resample_by=None):
+        # pylint: disable=invalid-name, too-many-branches
         '''
         Calculate the portfolio asset allocations using the method specified.
 

--- a/mlfinlab/portfolio_optimization/mean_variance.py
+++ b/mlfinlab/portfolio_optimization/mean_variance.py
@@ -41,7 +41,7 @@ class MeanVarianceOptimisation:
 
         # Calculate the returns if the user does not supply a asset returns matrix
         if asset_returns is None:
-            asset_returns = self._calculate_returns(asset_prices, resample_by=resample_by)
+            asset_returns = self._calculate_returns(asset_prices=asset_prices, resample_by=resample_by)
         assets = asset_returns.columns
 
         if solution == 'inverse_variance':

--- a/mlfinlab/tests/test_portfolio_optimisation.py
+++ b/mlfinlab/tests/test_portfolio_optimisation.py
@@ -147,7 +147,7 @@ class TestCLA(unittest.TestCase):
         cla.allocate(asset_prices=self.data, solution='min_volatility')
         data = self.data.copy()
         data.iloc[:, :] = 0.02320653
-        cla._initialise(asset_prices=data, resample_by='B', mean_asset_returns=None, returns_matrix=None)
+        cla._initialise(asset_prices=data, resample_by='B', expected_asset_returns=None, returns_matrix=None)
         assert cla.expected_returns[-1, 0] == 1e-5
 
     def test_lambda_for_zero_matrices(self):

--- a/mlfinlab/tests/test_portfolio_optimisation.py
+++ b/mlfinlab/tests/test_portfolio_optimisation.py
@@ -238,6 +238,18 @@ class TestCLA(unittest.TestCase):
             cla = CLA(calculate_returns="unknown_returns")
             cla.allocate(asset_prices=self.data, solution='cla_turning_points')
 
+    def test_resampling_asset_prices(self):
+        """
+        Test resampling of asset prices
+        """
+
+        cla = CLA()
+        cla.allocate(asset_prices=self.data, resample_by='B', solution='min_volatility')
+        weights = cla.weights.values[0]
+        assert (weights >= 0).all()
+        assert len(weights) == self.data.shape[1]
+        np.testing.assert_almost_equal(np.sum(weights), 1)
+
 class TestHRP(unittest.TestCase):
     """
     Tests different functions of the HRP algorithm class.
@@ -319,6 +331,18 @@ class TestHRP(unittest.TestCase):
             data = self.data.reset_index()
             hrp.allocate(asset_prices=data)
 
+    def test_resampling_asset_prices(self):
+        """
+        Test resampling of asset prices
+        """
+
+        hrp = HierarchicalRiskParity()
+        hrp.allocate(asset_prices=self.data, resample_by='B')
+        weights = hrp.weights.values[0]
+        assert (weights >= 0).all()
+        assert len(weights) == self.data.shape[1]
+        np.testing.assert_almost_equal(np.sum(weights), 1)
+
 class TestMVO(unittest.TestCase):
     """
     Tests the different functions of the Mean Variance Optimisation class
@@ -371,3 +395,15 @@ class TestMVO(unittest.TestCase):
             mvo = MeanVarianceOptimisation()
             data = self.data.reset_index()
             mvo.allocate(asset_prices=data, solution='inverse_variance')
+
+    def test_resampling_asset_prices(self):
+        """
+        Test resampling of asset prices
+        """
+
+        mvo = MeanVarianceOptimisation()
+        mvo.allocate(asset_prices=self.data, solution='inverse_variance', resample_by='B')
+        weights = mvo.weights.values[0]
+        assert (weights >= 0).all()
+        assert len(weights) == self.data.shape[1]
+        np.testing.assert_almost_equal(np.sum(weights), 1)

--- a/mlfinlab/tests/test_portfolio_optimisation.py
+++ b/mlfinlab/tests/test_portfolio_optimisation.py
@@ -229,6 +229,25 @@ class TestCLA(unittest.TestCase):
             data = self.data.reset_index()
             cla.allocate(asset_prices=data, solution='cla_turning_points')
 
+    def test_value_error_for_non_dataframe_returns(self):
+        """
+        Test ValueError on passing non-dataframe asset returns
+        """
+
+        with self.assertRaises(ValueError):
+            cla = CLA()
+            cla.allocate(returns_matrix=self.data.values, solution='cla_turning_points')
+
+    def test_value_error_for_non_date_index_in_returns(self):
+        """
+        Test ValueError on passing asset returns dataframe not indexed by date
+        """
+
+        with self.assertRaises(ValueError):
+            cla = CLA()
+            data = self.data.reset_index()
+            cla.allocate(returns_matrix=data, solution='cla_turning_points')
+
     def test_value_error_for_unknown_returns(self):
         """
         Test ValueError on passing unknown returns string
@@ -340,6 +359,25 @@ class TestHRP(unittest.TestCase):
             data = self.data.reset_index()
             hrp.allocate(asset_prices=data)
 
+    def test_value_error_for_non_dataframe_returns(self):
+        """
+        Test ValueError on passing non-dataframe asset returns
+        """
+
+        with self.assertRaises(ValueError):
+            hrp = HierarchicalRiskParity()
+            hrp.allocate(asset_returns=self.data.values)
+
+    def test_value_error_for_non_date_index_in_returns(self):
+        """
+        Test ValueError on passing asset returns dataframe not indexed by date
+        """
+
+        with self.assertRaises(ValueError):
+            hrp = HierarchicalRiskParity()
+            data = self.data.reset_index()
+            hrp.allocate(asset_returns=data)
+
     def test_resampling_asset_prices(self):
         """
         Test resampling of asset prices
@@ -414,6 +452,25 @@ class TestMVO(unittest.TestCase):
             data = self.data.reset_index()
             mvo.allocate(asset_prices=data, solution='inverse_variance')
 
+    def test_value_error_for_non_dataframe_returns(self):
+        """
+        Test ValueError on passing non-dataframe asset returns
+        """
+
+        with self.assertRaises(ValueError):
+            mvo = MeanVarianceOptimisation()
+            mvo.allocate(asset_returns=self.data.values, solution='inverse_variance')
+
+    def test_value_error_for_non_date_index_in_returns(self):
+        """
+        Test ValueError on passing asset returns dataframe not indexed by date
+        """
+
+        with self.assertRaises(ValueError):
+            mvo = MeanVarianceOptimisation()
+            data = self.data.reset_index()
+            mvo.allocate(asset_returns=data, solution='inverse_invariance')
+
     def test_resampling_asset_prices(self):
         """
         Test resampling of asset prices
@@ -434,3 +491,4 @@ class TestMVO(unittest.TestCase):
         with self.assertRaises(ValueError):
             mvo = MeanVarianceOptimisation()
             mvo.allocate()
+unittest.main()

--- a/mlfinlab/tests/test_portfolio_optimisation.py
+++ b/mlfinlab/tests/test_portfolio_optimisation.py
@@ -229,7 +229,7 @@ class TestCLA(unittest.TestCase):
             data = self.data.reset_index()
             cla.allocate(asset_prices=data, solution='cla_turning_points')
 
-    def test_value_error_for_non_dataframe_returns(self):
+    def test_error_for_non_dataframe_returns(self):
         """
         Test ValueError on passing non-dataframe asset returns
         """
@@ -238,7 +238,7 @@ class TestCLA(unittest.TestCase):
             cla = CLA()
             cla.allocate(returns_matrix=self.data.values, solution='cla_turning_points')
 
-    def test_value_error_for_non_date_index_in_returns(self):
+    def test_error_for_non_date_index_in_returns(self):
         """
         Test ValueError on passing asset returns dataframe not indexed by date
         """
@@ -269,7 +269,7 @@ class TestCLA(unittest.TestCase):
         assert len(weights) == self.data.shape[1]
         np.testing.assert_almost_equal(np.sum(weights), 1)
 
-    def test_all_inputs_None(self):
+    def test_all_inputs_none(self):
         """
         Test allocation when all inputs are None
         """
@@ -359,7 +359,7 @@ class TestHRP(unittest.TestCase):
             data = self.data.reset_index()
             hrp.allocate(asset_prices=data)
 
-    def test_value_error_for_non_dataframe_returns(self):
+    def test_error_for_non_dataframe_returns(self):
         """
         Test ValueError on passing non-dataframe asset returns
         """
@@ -368,7 +368,7 @@ class TestHRP(unittest.TestCase):
             hrp = HierarchicalRiskParity()
             hrp.allocate(asset_returns=self.data.values)
 
-    def test_value_error_for_non_date_index_in_returns(self):
+    def test_error_for_non_date_index_in_returns(self):
         """
         Test ValueError on passing asset returns dataframe not indexed by date
         """
@@ -390,7 +390,7 @@ class TestHRP(unittest.TestCase):
         assert len(weights) == self.data.shape[1]
         np.testing.assert_almost_equal(np.sum(weights), 1)
 
-    def test_all_inputs_None(self):
+    def test_all_inputs_none(self):
         """
         Test allocation when all inputs are None
         """
@@ -452,7 +452,7 @@ class TestMVO(unittest.TestCase):
             data = self.data.reset_index()
             mvo.allocate(asset_prices=data, solution='inverse_variance')
 
-    def test_value_error_for_non_dataframe_returns(self):
+    def test_error_for_non_dataframe_returns(self):
         """
         Test ValueError on passing non-dataframe asset returns
         """
@@ -461,7 +461,7 @@ class TestMVO(unittest.TestCase):
             mvo = MeanVarianceOptimisation()
             mvo.allocate(asset_returns=self.data.values, solution='inverse_variance')
 
-    def test_value_error_for_non_date_index_in_returns(self):
+    def test_error_for_non_date_index_in_returns(self):
         """
         Test ValueError on passing asset returns dataframe not indexed by date
         """
@@ -483,7 +483,7 @@ class TestMVO(unittest.TestCase):
         assert len(weights) == self.data.shape[1]
         np.testing.assert_almost_equal(np.sum(weights), 1)
 
-    def test_all_inputs_None(self):
+    def test_all_inputs_none(self):
         """
         Test allocation when all inputs are None
         """
@@ -491,4 +491,3 @@ class TestMVO(unittest.TestCase):
         with self.assertRaises(ValueError):
             mvo = MeanVarianceOptimisation()
             mvo.allocate()
-unittest.main()

--- a/mlfinlab/tests/test_portfolio_optimisation.py
+++ b/mlfinlab/tests/test_portfolio_optimisation.py
@@ -230,25 +230,6 @@ class TestCLA(unittest.TestCase):
             data = self.data.reset_index()
             cla.allocate(asset_prices=data, solution='cla_turning_points')
 
-    def test_error_for_non_dataframe_returns(self):
-        """
-        Test ValueError on passing non-dataframe asset returns
-        """
-
-        with self.assertRaises(ValueError):
-            cla = CLA()
-            cla.allocate(returns_matrix=self.data.values, solution='cla_turning_points')
-
-    def test_error_for_non_date_index_in_returns(self):
-        """
-        Test ValueError on passing asset returns dataframe not indexed by date
-        """
-
-        with self.assertRaises(ValueError):
-            cla = CLA()
-            data = self.data.reset_index()
-            cla.allocate(returns_matrix=data, solution='cla_turning_points')
-
     def test_value_error_for_unknown_returns(self):
         """
         Test ValueError on passing unknown returns string
@@ -360,25 +341,6 @@ class TestHRP(unittest.TestCase):
             data = self.data.reset_index()
             hrp.allocate(asset_prices=data)
 
-    def test_error_for_non_dataframe_returns(self):
-        """
-        Test ValueError on passing non-dataframe asset returns
-        """
-
-        with self.assertRaises(ValueError):
-            hrp = HierarchicalRiskParity()
-            hrp.allocate(asset_returns=self.data.values)
-
-    def test_error_for_non_date_index_in_returns(self):
-        """
-        Test ValueError on passing asset returns dataframe not indexed by date
-        """
-
-        with self.assertRaises(ValueError):
-            hrp = HierarchicalRiskParity()
-            data = self.data.reset_index()
-            hrp.allocate(asset_returns=data)
-
     def test_resampling_asset_prices(self):
         """
         Test resampling of asset prices
@@ -452,25 +414,6 @@ class TestMVO(unittest.TestCase):
             mvo = MeanVarianceOptimisation()
             data = self.data.reset_index()
             mvo.allocate(asset_prices=data, solution='inverse_variance')
-
-    def test_error_for_non_dataframe_returns(self):
-        """
-        Test ValueError on passing non-dataframe asset returns
-        """
-
-        with self.assertRaises(ValueError):
-            mvo = MeanVarianceOptimisation()
-            mvo.allocate(asset_returns=self.data.values, solution='inverse_variance')
-
-    def test_error_for_non_date_index_in_returns(self):
-        """
-        Test ValueError on passing asset returns dataframe not indexed by date
-        """
-
-        with self.assertRaises(ValueError):
-            mvo = MeanVarianceOptimisation()
-            data = self.data.reset_index()
-            mvo.allocate(asset_returns=data, solution='inverse_invariance')
 
     def test_resampling_asset_prices(self):
         """

--- a/mlfinlab/tests/test_portfolio_optimisation.py
+++ b/mlfinlab/tests/test_portfolio_optimisation.py
@@ -434,5 +434,3 @@ class TestMVO(unittest.TestCase):
         with self.assertRaises(ValueError):
             mvo = MeanVarianceOptimisation()
             mvo.allocate()
-
-unittest.main()

--- a/mlfinlab/tests/test_portfolio_optimisation.py
+++ b/mlfinlab/tests/test_portfolio_optimisation.py
@@ -147,7 +147,7 @@ class TestCLA(unittest.TestCase):
         cla.allocate(asset_prices=self.data, solution='min_volatility')
         data = self.data.copy()
         data.iloc[:, :] = 0.02320653
-        cla._initialise(asset_prices=data, resample_by='B')
+        cla._initialise(asset_prices=data, resample_by='B', mean_asset_returns=None, returns_matrix=None)
         assert cla.expected_returns[-1, 0] == 1e-5
 
     def test_lambda_for_zero_matrices(self):
@@ -250,6 +250,15 @@ class TestCLA(unittest.TestCase):
         assert len(weights) == self.data.shape[1]
         np.testing.assert_almost_equal(np.sum(weights), 1)
 
+    def test_all_inputs_None(self):
+        """
+        Test allocation when all inputs are None
+        """
+
+        with self.assertRaises(ValueError):
+            cla = CLA()
+            cla.allocate()
+
 class TestHRP(unittest.TestCase):
     """
     Tests different functions of the HRP algorithm class.
@@ -343,6 +352,15 @@ class TestHRP(unittest.TestCase):
         assert len(weights) == self.data.shape[1]
         np.testing.assert_almost_equal(np.sum(weights), 1)
 
+    def test_all_inputs_None(self):
+        """
+        Test allocation when all inputs are None
+        """
+
+        with self.assertRaises(ValueError):
+            hrp = HierarchicalRiskParity()
+            hrp.allocate()
+
 class TestMVO(unittest.TestCase):
     """
     Tests the different functions of the Mean Variance Optimisation class
@@ -407,3 +425,14 @@ class TestMVO(unittest.TestCase):
         assert (weights >= 0).all()
         assert len(weights) == self.data.shape[1]
         np.testing.assert_almost_equal(np.sum(weights), 1)
+
+    def test_all_inputs_None(self):
+        """
+        Test allocation when all inputs are None
+        """
+
+        with self.assertRaises(ValueError):
+            mvo = MeanVarianceOptimisation()
+            mvo.allocate()
+
+unittest.main()

--- a/mlfinlab/tests/test_portfolio_optimisation.py
+++ b/mlfinlab/tests/test_portfolio_optimisation.py
@@ -12,6 +12,7 @@ from mlfinlab.portfolio_optimization.mean_variance import MeanVarianceOptimisati
 
 
 class TestCLA(unittest.TestCase):
+    # pylint: disable=too-many-public-methods
     """
     Tests different functions of the CLA class.
     """


### PR DESCRIPTION
# Description
This PR adds some enhancements and bug fixes to the portfolio optimisation module
1. Make default value of resample_by as None
2. Add feature for users to supply their own asset returns matrix rather than restricting returns calculation to what is implemented in the module

## Type of change
Bug fixes and some enhancements

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Added unittests for the features and bug fixes

**Test Configuration**:
* Operating system - MacOS Mojave
* IDE used - Pycharm


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
