### PR TITLE
Fix sample weights functions compatibility with pandas 1.0.1

### DIFF
--- a/mlfinlab/sampling/concurrent.py
+++ b/mlfinlab/sampling/concurrent.py
@@ -2,7 +2,6 @@
 Logic regarding concurrent labels from chapter 4.
 """
 
-import numpy as np
 import pandas as pd
 
 from mlfinlab.util.multiprocess import mp_pandas_obj

--- a/mlfinlab/sampling/concurrent.py
+++ b/mlfinlab/sampling/concurrent.py
@@ -26,7 +26,7 @@ def num_concurrent_events(close_series_index, label_endtime, molecule):
     label_endtime = label_endtime.loc[:label_endtime[molecule].max()]
 
     # Count events spanning a bar
-    nearest_index = close_series_index.searchsorted(np.array([label_endtime.index[0], label_endtime.max()]))
+    nearest_index = close_series_index.searchsorted(pd.DatetimeIndex([label_endtime.index[0], label_endtime.max()]))
     count = pd.Series(0, index=close_series_index[nearest_index[0]:nearest_index[1] + 1])
     for t_in, t_out in label_endtime.iteritems():
         count.loc[t_in:t_out] += 1


### PR DESCRIPTION
# Description

Fix return/time decaying sample weights calculations compatibility with pandas 1.0.1


- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?



- [ ] test_sample_weights.py



# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
