### PR TITLE
Replace pd.Series to pd.DataFrame in fracdiff docstrings

### DIFF
--- a/mlfinlab/features/fracdiff.py
+++ b/mlfinlab/features/fracdiff.py
@@ -162,7 +162,7 @@ class FractionalDifferentiation:
         Note 1: thresh determines the cut-off weight for the window
         Note 2: diff_amt can be any positive fractional, not necessarity bounded [0, 1].
 
-        :param series: (pd.Dataframe)
+        :param series: (pd.DataFrame)
         :param diff_amt: (float) differencing amount
         :param thresh: (float) threshold for minimum weight
         :return: (pd.DataFrame) a data frame of differenced series

--- a/mlfinlab/features/fracdiff.py
+++ b/mlfinlab/features/fracdiff.py
@@ -67,7 +67,7 @@ class FractionalDifferentiation:
         Note 1: For thresh-1, nothing is skipped
         Note 2: diff_amt can be any positive fractional, not necessarility bounded [0, 1]
 
-        :param series: (pd.Series) a time series that needs to be differenced
+        :param series: (pd.DataFrame) a time series that needs to be differenced
         :param diff_amt: (float) Differencing amount
         :param thresh: (float) threshold or epsilon
         :return: (pd.DataFrame) data frame of differenced series
@@ -162,7 +162,7 @@ class FractionalDifferentiation:
         Note 1: thresh determines the cut-off weight for the window
         Note 2: diff_amt can be any positive fractional, not necessarity bounded [0, 1].
 
-        :param series: (pd.Series)
+        :param series: (pd.Dataframe)
         :param diff_amt: (float) differencing amount
         :param thresh: (float) threshold for minimum weight
         :return: (pd.DataFrame) a data frame of differenced series


### PR DESCRIPTION
# Description

The `series` parameter has to be a DataFrame because in the body of the
fracdiff functions one iterates over its columns. pd.Series does not
have columns, only pd.DataFrame does

## Type of change

Please delete options that are not relevant.

- [x ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* Operating system
* IDE used


# Checklist:

- [x ] My code follows the style guidelines of this project
- [ x] I have performed a self-review of my own code
- [ x] I have commented my code, particularly in hard-to-understand areas
- [x ] I have made corresponding changes to the documentation
- [ x] My changes generate no new warnings
- [ x] I have added tests that prove my fix is effective or that my feature works
- [ x] New and existing unit tests pass locally with my changes
- [ x] Any dependent changes have been merged and published in downstream modules
