### PR TITLE
Fix inconsitency of date precision for apply_pt_sl_on_t1

### DIFF
--- a/mlfinlab/labeling/labeling.py
+++ b/mlfinlab/labeling/labeling.py
@@ -45,12 +45,15 @@ def apply_pt_sl_on_t1(close, events, pt_sl, molecule):  # pragma: no cover
     else:
         stop_loss = pd.Series(index=events.index)  # NaNs
 
+    out['pt'] = pd.Series(dtype=events.index.dtype)
+    out['sl'] = pd.Series(dtype=events.index.dtype)
+
     # Get events
     for loc, vertical_barrier in events_['t1'].fillna(close.index[-1]).iteritems():
         closing_prices = close[loc: vertical_barrier]  # Path prices for a given trade
         cum_returns = (closing_prices / close[loc] - 1) * events_.at[loc, 'side']  # Path returns
-        out.loc[loc, 'sl'] = cum_returns[cum_returns < stop_loss[loc]].index.min()  # Earliest stop loss date
-        out.loc[loc, 'pt'] = cum_returns[cum_returns > profit_taking[loc]].index.min()  # Earliest profit taking date
+        out.at[loc, 'sl'] = cum_returns[cum_returns < stop_loss[loc]].index.min()  # Earliest stop loss date
+        out.at[loc, 'pt'] = cum_returns[cum_returns > profit_taking[loc]].index.min()  # Earliest profit taking date
 
     return out
 
@@ -149,7 +152,7 @@ def get_events(close, t_events, pt_sl, target, min_ret, num_threads, vertical_ba
                                       pt_sl=pt_sl_)
 
     for ind in events.index:
-        events.loc[ind, 't1'] = first_touch_dates.loc[ind, :].dropna().min()
+        events.at[ind, 't1'] = first_touch_dates.loc[ind, :].dropna().min()
 
     if side_prediction is None:
         events = events.drop('side', axis=1)


### PR DESCRIPTION
# Description

For some unknown reason there is a inconsistency of date precision between events.index and events.t1 after running apply_pt_sl_on_t1. I found the problem when I tried to run the following code:

`bars.loc[events.t1, 'some_col'] = some_val`

which raised a KeyError Exception. It failed both for ms-precision indices and also ns-precision indices.

See attached screenshot
<img width="1362" alt="Screenshot 2020-04-09 at 17 02 23" src="https://user-images.githubusercontent.com/8958103/78921708-9b279600-7a95-11ea-9688-9fe3ec4d7e92.png">


## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

`bars.loc[events.t1, 'some_col'] = some_val` now works :) 

**Test Configuration**:
* Operating system: macOS Catalina
* IDE used: PyCharm
* Pandas version: 0.25.3


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
