### PR TITLE
Speedup for ef3m in bet sizing

### DIFF
--- a/mlfinlab/bet_sizing/ef3m.py
+++ b/mlfinlab/bet_sizing/ef3m.py
@@ -447,14 +447,10 @@ def iter_5_jit(mu_2, p_1, m_1, m_2, m_3, m_4, m_5):
         mu_2_squared = a_1 - 3 * sigma_2 ** 2
 
         # Validity check 7: break to avoid complex numbers.
-
         # TODO Avoid Numba object mode.
         # Numba does not support numpy.iscomplex. This creates an overhead.
         with objmode(mu_2_squared_is_complex="boolean"):
-            if np.iscomplex(mu_2_squared):
-                mu_2_squared_is_complex = True
-            else:
-                mu_2_squared_is_complex = False
+            mu_2_squared_is_complex = bool(np.iscomplex(mu_2_squared))
         if mu_2_squared_is_complex or mu_2_squared < 0:
             break
 

--- a/mlfinlab/bet_sizing/ef3m.py
+++ b/mlfinlab/bet_sizing/ef3m.py
@@ -304,9 +304,8 @@ def most_likely_parameters(data, ignore_columns='error', res=10_000):
 
 
 @njit()
-def iter_4_jit(mu_2, p_1, m_1, m_2, m_3, m_4):
+def iter_4_jit(mu_2, p_1, m_1, m_2, m_3, m_4):  # pragma: no cover
     """
-    
     "Numbarized" evaluation of the set of equations that make up variant #1 of the EF3M algorithm (fitting using the first
     four moments).
 
@@ -383,7 +382,7 @@ def iter_4_jit(mu_2, p_1, m_1, m_2, m_3, m_4):
 
 
 @njit()
-def iter_5_jit(mu_2, p_1, m_1, m_2, m_3, m_4, m_5):
+def iter_5_jit(mu_2, p_1, m_1, m_2, m_3, m_4, m_5):  # pragma: no cover
     """
     "Numbarized" evaluation of the set of equations that make up variant #2 of the EF3M algorithm (fitting using the first five
     moments).

--- a/mlfinlab/bet_sizing/ef3m.py
+++ b/mlfinlab/bet_sizing/ef3m.py
@@ -10,6 +10,7 @@ import numpy as np
 import pandas as pd
 from scipy.special import comb
 from scipy.stats import gaussian_kde
+from numba import njit, objmode
 
 
 class M2N:
@@ -139,56 +140,13 @@ class M2N:
         :return: (list) List of estimated parameter if no invalid values are encountered (e.g. complex values,
          divide-by-zero), otherwise an empty list is returned.
         """
-        m_1, m_2, m_3, m_4 = self.moments[0:4]  # Expand list of moments to individual variables for clarity.
-        param_list = []
-
-        # Using a while-loop here to be able to use 'break' functionality.
-        # We need to stop the calculation at any given step to avoid throwing warnings or errors,
-        # and be in control of our return values. I'm open to other suggestions, but multiple return statements isn't
-        # one of them.
-        while True:
-            # Calculate mu_1, Equation (22).
-            mu_1 = (m_1 - (1 - p_1) * mu_2) / p_1
-
-            # Calculate sigma_2, Equation (24)
-            if (3 * (1 - p_1) * (mu_2 - mu_1)) == 0:
-                # Validity check 1: Check for divide-by-zero.
-                break
-
-            sigma_2_squared = ((m_3 + 2 * p_1 * mu_1**3 + (p_1 - 1) * mu_2**3 - 3 * mu_1 * (m_2 + mu_2**2 * (p_1-1))) /
-                               (3*(1-p_1)*(mu_2-mu_1)))
-            if sigma_2_squared < 0:
-                # Validity check 2: Prevent potential complex values.
-                break
-
-            sigma_2 = sigma_2_squared**0.5
-            # Calculate sigma_1, Equation (23)
-            sigma_1_squared = ((m_2 - sigma_2**2 - mu_2**2) / p_1 + sigma_2**2 + mu_2**2 - mu_1**2)
-
-            if sigma_1_squared < 0:
-                # Validity check 3: Prevent potential complex values.
-                break
-            sigma_1 = sigma_1_squared**0.5
-
-            # Adjust guess for p_1, Equation (25)
-            p_1_deno = (3 * (sigma_1**4 - sigma_2**4) + 6 * (sigma_1**2 * mu_1**2 - sigma_2**2 * mu_2**2) + mu_1**4 -
-                        mu_2**4)
-            if p_1_deno == 0:
-                # Validity check 5: Break if about to divide by zero.
-                break
-
-            p_1 = (m_4 - 3*sigma_2**4 - 6*sigma_2**2*mu_2**2 - mu_2**4) / p_1_deno
-            if (p_1 < 0) or (p_1 > 1):
-                # Validity check 6: The probability must be between zero and one.
-                break
-
-            # Add all new parameter estimates to the return list if no break has occurred before now.
-            param_list = [mu_1, mu_2, sigma_1, sigma_2, p_1]
-
-            # We only want this to execute once at most, so call a final break if one hasn't been called yet.
-            break
+        m_1, m_2, m_3, m_4 = self.moments[
+            0:4
+        ]  # Expand list of moments to individual variables for clarity.
 
         # Check to see if every value made it through.
+        param_list = iter_4_jit(mu_2, p_1, m_1, m_2, m_3, m_4)
+        param_list = param_list.tolist()
         if len(param_list) < 5:
             return []
 
@@ -204,71 +162,19 @@ class M2N:
         :return: (list) List of estimated parameter if no invalid values are encountered (e.g. complex values,
          divide-by-zero), otherwise an empty list is returned.
         """
-        m_1, m_2, m_3, m_4, m_5 = self.moments  # Expand list of moments to individual variables for clarity.
+        (
+            m_1,
+            m_2,
+            m_3,
+            m_4,
+            m_5,
+        ) = self.moments  # Expand list of moments to individual variables for clarity.
 
-        # Using a while-loop here to be able to use 'break' functionality.
-        # We need to stop the calculation at any given step to avoid throwing warnings or errors, and be in control
-        # of our return values. I'm open to other suggestions, but multiple return statements isn't one of them.
-        param_list = []
-        while True:
-            # Calculate mu_1, Equation (22).
-            mu_1 = (m_1 - (1 - p_1) * mu_2) / p_1
-            if (3 * (1 - p_1) * (mu_2 - mu_1)) == 0:
-                # Validity check 1: check for divide-by-zero.
-                break
+        # Call numba decorated function to do the actual calculations
+        param_list = iter_5_jit(mu_2, p_1, m_1, m_2, m_3, m_4, m_5)
 
-            # Calculate sigma_2, Equation (24).
-            sigma_2_squared = ((m_3 + 2 * p_1 * mu_1**3 + (p_1-1) * mu_2**3 - 3 * mu_1 * (m_2 + mu_2**2 * (p_1-1))) /
-                               (3*(1-p_1)*(mu_2-mu_1)))
-            if sigma_2_squared < 0:
-                # Validity check 2: check for upcoming complex numbers.
-                break
-            sigma_2 = sigma_2_squared**0.5
+        param_list = param_list.tolist()
 
-            # Calculate sigma_1, Equation (23).
-            sigma_1_squared = ((m_2 - sigma_2**2 - mu_2**2)/p_1 + sigma_2**2 + mu_2**2 - mu_1**2)
-            if sigma_1_squared < 0:
-                # Validity check 3: check for upcoming complex numbers.
-                break
-            sigma_1 = sigma_1_squared**0.5
-
-            # Adjust the guess for mu_2, Equation (27).
-            if (1 - p_1) < 1e-4:
-                # Validity check 5: break to prevent divide-by-zero.
-                break
-
-            a_1_squared = (6 * sigma_2**4 + (m_4 - p_1 * (3 * sigma_1**4 + 6 * sigma_1**2 * mu_1**2 + mu_1**4)) /
-                           (1-p_1))
-            if a_1_squared < 0:
-                # Validity check 6: break to avoid taking the square root of negative number.
-                break
-
-            a_1 = a_1_squared**0.5
-            mu_2_squared = (a_1 - 3 * sigma_2**2)
-            if np.iscomplex(mu_2_squared) or mu_2_squared < 0:
-                # Validity check 7: break to avoid complex numbers.
-                break
-
-            mu_2 = mu_2_squared**0.5
-            # Adjust guess for p_1, Equation (28, 29).
-            a_2 = 15 * sigma_1**4 * mu_1 + 10 * sigma_1**2 * mu_1**3 + mu_1**5
-            b_2 = 15 * sigma_2**4 * mu_2 + 10 * sigma_2**2 * mu_2**3 + mu_2**5
-            if (a_2 - b_2) == 0:
-                # Validity check 8: break to prevent divide-by-zero.
-                break
-
-            p_1 = (m_5 - b_2) / (a_2 - b_2)
-            if (p_1 < 0) or (p_1 > 1):
-                # Validity check 9: p_1 value must be between 0 and 1.
-                break
-
-            # Add all new parameter estimates to the return list if no break has occurred before now.
-            param_list = [mu_1, mu_2, sigma_1, sigma_2, p_1]
-
-            # We only want this to execute once at most, so call a final break if one hasn't been called yet.
-            break
-
-        # Check to see if every value made it through.
         if len(param_list) < 5:
             return []
 
@@ -395,3 +301,180 @@ def most_likely_parameters(data, ignore_columns='error', res=10_000):
         d_results[col] = top_value
 
     return d_results
+
+
+@njit()
+def iter_4_jit(mu_2, p_1, m_1, m_2, m_3, m_4):
+    """
+    
+    "Numbarized" evaluation of the set of equations that make up variant #1 of the EF3M algorithm (fitting using the first
+    four moments).
+
+    :param mu_2: (float) Initial parameter value for mu_2
+    :param p_1: (float) Probability defining the mixture; p_1, 1 - p_1
+    :param m_1, m_2, m_3, m_4: (float) The first four (1... 4) raw moments of the mixture distribution.
+    :return: (list) List of estimated parameter if no invalid values are encountered (e.g. complex values,
+        divide-by-zero), otherwise an empty list is returned.
+    """
+    param_list = np.empty(0, dtype=np.float64)
+
+    # Using a while-loop here to be able to use 'break' functionality.
+    # We need to stop the calculation at any given step to avoid throwing warnings or errors,
+    # and be in control of our return values. I'm open to other suggestions, but multiple return statements isn't
+    # one of them.
+    while True:
+        # Calculate mu_1, Equation (22).
+        mu_1 = (m_1 - (1 - p_1) * mu_2) / p_1
+
+        # Calculate sigma_2, Equation (24)
+        if (3 * (1 - p_1) * (mu_2 - mu_1)) == 0:
+            # Validity check 1: Check for divide-by-zero.
+            break
+
+        sigma_2_squared = (
+            m_3
+            + 2 * p_1 * mu_1 ** 3
+            + (p_1 - 1) * mu_2 ** 3
+            - 3 * mu_1 * (m_2 + mu_2 ** 2 * (p_1 - 1))
+        ) / (3 * (1 - p_1) * (mu_2 - mu_1))
+        if sigma_2_squared < 0:
+            # Validity check 2: Prevent potential complex values.
+            break
+
+        sigma_2 = sigma_2_squared ** 0.5
+        # Calculate sigma_1, Equation (23)
+        sigma_1_squared = (
+            (m_2 - sigma_2 ** 2 - mu_2 ** 2) / p_1
+            + sigma_2 ** 2
+            + mu_2 ** 2
+            - mu_1 ** 2
+        )
+
+        if sigma_1_squared < 0:
+            # Validity check 3: Prevent potential complex values.
+            break
+        sigma_1 = sigma_1_squared ** 0.5
+
+        # Adjust guess for p_1, Equation (25)
+        p_1_deno = (
+            3 * (sigma_1 ** 4 - sigma_2 ** 4)
+            + 6 * (sigma_1 ** 2 * mu_1 ** 2 - sigma_2 ** 2 * mu_2 ** 2)
+            + mu_1 ** 4
+            - mu_2 ** 4
+        )
+        if p_1_deno == 0:
+            # Validity check 5: Break if about to divide by zero.
+            break
+
+        p_1 = (
+            m_4 - 3 * sigma_2 ** 4 - 6 * sigma_2 ** 2 * mu_2 ** 2 - mu_2 ** 4
+        ) / p_1_deno
+        if (p_1 < 0) or (p_1 > 1):
+            # Validity check 6: The probability must be between zero and one.
+            break
+
+        # Add all new parameter estimates to the return list if no break has occurred before now.
+        param_list = np.array([mu_1, mu_2, sigma_1, sigma_2, p_1], dtype=np.float64)
+
+        # We only want this to execute once at most, so call a final break if one hasn't been called yet.
+        break
+
+    return param_list
+
+
+@njit()
+def iter_5_jit(mu_2, p_1, m_1, m_2, m_3, m_4, m_5):
+    """
+    "Numbarized" evaluation of the set of equations that make up variant #2 of the EF3M algorithm (fitting using the first five
+    moments).
+
+    :param mu_2: (float) Initial parameter value for mu_2
+    :param p_1: (float) Probability defining the mixture; p_1, 1-p_1
+    :param m_1, m_2, m_3, m_4, m_5: (float) The first five (1... 5) raw moments of the mixture distribution.
+    :return: (list) List of estimated parameter if no invalid values are encountered (e.g. complex values,
+        divide-by-zero), otherwise an empty list is returned.
+    """
+    param_list = np.empty(0, dtype=np.float64)
+
+    # Using a while-loop here to be able to use 'break' functionality.
+    # We need to stop the calculation at any given step to avoid throwing warnings or errors, and be in control
+    # of our return values. I'm open to other suggestions, but multiple return statements isn't one of them.
+    while True:
+        # Calculate mu_1, Equation (22).
+        mu_1 = (m_1 - (1 - p_1) * mu_2) / p_1
+        if (3 * (1 - p_1) * (mu_2 - mu_1)) == 0:
+            # Validity check 1: check for divide-by-zero.
+            break
+
+        # Calculate sigma_2, Equation (24).
+        sigma_2_squared = (
+            m_3
+            + 2 * p_1 * mu_1 ** 3
+            + (p_1 - 1) * mu_2 ** 3
+            - 3 * mu_1 * (m_2 + mu_2 ** 2 * (p_1 - 1))
+        ) / (3 * (1 - p_1) * (mu_2 - mu_1))
+
+        if sigma_2_squared < 0:
+            # Validity check 2: check for upcoming complex numbers.
+            break
+        sigma_2 = sigma_2_squared ** 0.5
+
+        # Calculate sigma_1, Equation (23).
+        sigma_1_squared = (
+            (m_2 - sigma_2 ** 2 - mu_2 ** 2) / p_1
+            + sigma_2 ** 2
+            + mu_2 ** 2
+            - mu_1 ** 2
+        )
+        if sigma_1_squared < 0:
+            # Validity check 3: check for upcoming complex numbers.
+            break
+        sigma_1 = sigma_1_squared ** 0.5
+
+        # Adjust the guess for mu_2, Equation (27).
+        if (1 - p_1) < 1e-4:
+            # Validity check 5: break to prevent divide-by-zero.
+            break
+
+        a_1_squared = 6 * sigma_2 ** 4 + (
+            m_4 - p_1 * (3 * sigma_1 ** 4 + 6 * sigma_1 ** 2 * mu_1 ** 2 + mu_1 ** 4)
+        ) / (1 - p_1)
+        if a_1_squared < 0:
+            # Validity check 6: break to avoid taking the square root of negative number.
+            break
+
+        a_1 = a_1_squared ** 0.5
+        mu_2_squared = a_1 - 3 * sigma_2 ** 2
+
+        # Validity check 7: break to avoid complex numbers.
+
+        # TODO Avoid Numba object mode.
+        # Numba does not support numpy.iscomplex. This creates an overhead.
+        with objmode(mu_2_squared_is_complex="boolean"):
+            if np.iscomplex(mu_2_squared):
+                mu_2_squared_is_complex = True
+            else:
+                mu_2_squared_is_complex = False
+        if mu_2_squared_is_complex or mu_2_squared < 0:
+            break
+
+        mu_2 = mu_2_squared ** 0.5
+        # Adjust guess for p_1, Equation (28, 29).
+        a_2 = 15 * sigma_1 ** 4 * mu_1 + 10 * sigma_1 ** 2 * mu_1 ** 3 + mu_1 ** 5
+        b_2 = 15 * sigma_2 ** 4 * mu_2 + 10 * sigma_2 ** 2 * mu_2 ** 3 + mu_2 ** 5
+        if (a_2 - b_2) == 0:
+            # Validity check 8: break to prevent divide-by-zero.
+            break
+
+        p_1 = (m_5 - b_2) / (a_2 - b_2)
+        if (p_1 < 0) or (p_1 > 1):
+            # Validity check 9: p_1 value must be between 0 and 1.
+            break
+
+        # Add all new parameter estimates to the return list if no break has occurred before now.
+        param_list = np.array([mu_1, mu_2, sigma_1, sigma_2, p_1], dtype=np.float64)
+
+        # We only want this to execute once at most, so call a final break if one hasn't been called yet.
+        break
+
+    return param_list

--- a/mlfinlab/tests/test_ef3m.py
+++ b/mlfinlab/tests/test_ef3m.py
@@ -322,7 +322,7 @@ class TestM2NFit(unittest.TestCase):
 
 class TestM2NEF3M(unittest.TestCase):
     """
-    Tets the EF3M algorithms of the M2N module.
+    Tests the EF3M algorithms of the M2N module.
     """
 
     def test_ef3m_variant_1(self):

--- a/mlfinlab/tests/test_ef3m.py
+++ b/mlfinlab/tests/test_ef3m.py
@@ -7,13 +7,21 @@ import numpy as np
 import pandas as pd
 from scipy.special import comb
 
-from mlfinlab.bet_sizing.ef3m import M2N, centered_moment, raw_moment, most_likely_parameters
+from mlfinlab.bet_sizing.ef3m import (
+    M2N,
+    centered_moment,
+    raw_moment,
+    most_likely_parameters,
+    iter_4_jit,
+    iter_5_jit,
+)
 
 
 class TestM2NConstructor(unittest.TestCase):
     """
     Tests the constructor method of the M2N class.
     """
+
     def test_m2n_constructor(self):
         """
         Tests that the constructor of the M2N class executes properly.
@@ -310,6 +318,60 @@ class TestM2NFit(unittest.TestCase):
         m2n_test = M2N(moments_test, epsilon_test, factor_test, n_runs_test, variant_test, max_iter_test)
         m2n_test.fit(mu_2=mu_2_test)
         self.assertTrue(len(m2n_test.parameters) == 5)
+
+
+class TestM2NEF3M(unittest.TestCase):
+    """
+    Tets the EF3M algorithms of the M2N module.
+    """
+
+    def test_ef3m_variant_1(self):
+        """
+        Tests the 'iter_4_jit' function of the M2N module (using variant 1).
+        """
+        mu_2 = -0.5876905479546004
+        p_1 = 0.020950069267730465
+        moments_test = [
+            -0.59,
+            9.830000000000002,
+            -19.922000000000004,
+            264.254,
+        ]
+        expected_parameters = [
+            -0.6979265579594388,
+            -0.5876905479546004,
+            20.80638279572574,
+            0.6488995559493259,
+            0.0004662589937450317,
+        ]
+        param_list = iter_4_jit(mu_2, p_1, *moments_test)
+        param_list = param_list.tolist()
+        self.assertTrue(expected_parameters == param_list)
+
+    def test_ef3m_variant_2(self):
+        """
+        Tests the 'iter_5_jit' function of the M2N module (using variant 2).
+        """
+        mu_2 = -0.07037328978510915
+        p_1 = 0.09166890087206325
+        moments_test = [
+            -0.59,
+            9.830000000000002,
+            -19.922000000000004,
+            264.254,
+            -818.2100000000003,
+        ]
+        expected_parameters = [
+            -5.738890150700704,
+            0.1755905244444409,
+            0.862038546663441,
+            2.723656932895561,
+            0.12317856407155195,
+        ]
+        param_list = iter_5_jit(mu_2, p_1, *moments_test)
+        param_list = param_list.tolist()
+        self.assertTrue(expected_parameters == param_list)
+
 
 class TestM2NSingleFitLoop(unittest.TestCase):
     """


### PR DESCRIPTION
# Description

Increases speed of calculations by making some minor changes to the code to make it compatible with Numba.

## Type of change

- [x] Improvement (modifies existing code to improve speed, usability, readability etc.)

# How Has This Been Tested?

- [x] ```python -m unittest test_bet_sizing.TestBetSizeReserve.test_bet_size_reserve_default```
- [x] ```python -m unittest test_ef3m.py```

**Test Configuration**:
* Manjaro Linux
* Visual Studio Code


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

# Notes

Below are the timed test results for ```python -m unittest test_bet_sizing.TestBetSizeReserve.test_bet_size_reserve_default``` which should give an idea for the aprx. increase in speed:

Native:
```
Ran 1 test in 79.200s

OK
python -m unittest   80,26s user 0,23s system 99% cpu 1:20,86 total

```

Numba:
```
Ran 1 test in 45.126s

OK
python -m unittest   46,31s user 0,28s system 99% cpu 46,812 total
```

I also ran ```python -m unittest test_bet_sizing.TestBetSizeReserve.test_bet_size_reserve_default``` modified to use variant 1:

Native:
```
Ran 1 test in 5876.010s

OK
python -m unittest   5862,62s user 2,21s system 99% cpu 1:37:57,66 total
```

Numba:
```
Ran 1 test in 1498.253s

OK
python -m unittest   1495,46s user 0,55s system 99% cpu 24:59,90 total
```

When running ```python -m unittest test_ef3m.py``` the Numba version is actually slower. This is probably due to the overhead of the Numba JIT compiler offsetting any speed gains. I am assuming the `test_ef3m` tests were written with a small data size in mind and the previous tests are more representative for real world usage:

Native:
```
Ran 29 tests in 5.213s

OK
python -m unittest test_ef3m.py  6,60s user 0,16s system 98% cpu 6,849 total
```

Numba:
```
Ran 29 tests in 8.635s

OK
python -m unittest test_ef3m.py  10,05s user 0,19s system 98% cpu 10,369 total
```

