### PR TITLE
Feature clusters update

### DIFF
--- a/mlfinlab/clustering/feature_clusters.py
+++ b/mlfinlab/clustering/feature_clusters.py
@@ -42,14 +42,15 @@ def get_feature_clusters(X: pd.DataFrame, dependence_metric: str, distance_metri
                                 for correction of the same.
     :return: (list) Feature subsets.
     """
-    # Checking if dataset contains features low silhouette
-    X = _check_for_low_silhouette_scores(X, critical_threshold)
 
     # Get the dependence matrix
     if dependence_metric != 'linear':
         dep_matrix = get_dependence_matrix(X, dependence_method=dependence_metric)
     else:
         dep_matrix = X.corr()
+
+    # Checking if dataset contains features low silhouette
+    X = _check_for_low_silhouette_scores(X, dep_matrix, critical_threshold)
 
     if n_clusters is None and (distance_metric is None or linkage_method is None):
         return list(get_onc_clusters(dep_matrix.fillna(0))[1].values())  # Get optimal number of clusters
@@ -133,7 +134,8 @@ def _combine_features(X, clusters, exclude_key) -> np.array:
     return np.array(new_exog)
 
 
-def _check_for_low_silhouette_scores(X: pd.DataFrame, critical_threshold: float = 0.0) -> pd.DataFrame:
+def _check_for_low_silhouette_scores(X: pd.DataFrame, dep_matrix:pd.DataFrame,
+                                     critical_threshold: float = 0.0) -> pd.DataFrame:
     """
     Machine Learning for Asset Managers
     Snippet 6.5.2.1 , page 85. Step 1: Features Clustering (last paragraph)
@@ -143,10 +145,11 @@ def _check_for_low_silhouette_scores(X: pd.DataFrame, critical_threshold: float 
     clusters and it needs a transformation.
 
     :param X: (pd.DataFrame) Dataframe of features.
+    :param dep_matrix: (pd.DataFrame) Dataframe with dependences between features.
     :param critical_threshold: (float) Threshold for determining low silhouette score.
     :return: (pd.DataFrame) Dataframe of features.
     """
-    _, clstrs, silh = get_onc_clusters(X.corr())
+    _, clstrs, silh = get_onc_clusters(dep_matrix)
     low_silh_feat = silh[silh < critical_threshold].index
     if len(low_silh_feat) > 0:
         print(f'{len(low_silh_feat)} feature/s found with low silhouette score {low_silh_feat}. Returning the transformed dataset')

--- a/mlfinlab/clustering/feature_clusters.py
+++ b/mlfinlab/clustering/feature_clusters.py
@@ -134,7 +134,7 @@ def _combine_features(X, clusters, exclude_key) -> np.array:
     return np.array(new_exog)
 
 
-def _check_for_low_silhouette_scores(X: pd.DataFrame, dep_matrix:pd.DataFrame,
+def _check_for_low_silhouette_scores(X: pd.DataFrame, dep_matrix: pd.DataFrame,
                                      critical_threshold: float = 0.0) -> pd.DataFrame:
     """
     Machine Learning for Asset Managers

--- a/mlfinlab/clustering/onc.py
+++ b/mlfinlab/clustering/onc.py
@@ -59,7 +59,7 @@ def _cluster_kmeans_base(corr_mat: pd.DataFrame, max_num_clusters: int = 10, rep
 
     # Fill main diagonal of corr matrix with 1s to avoid elements being close to 1 with e-16.
     # As this previously caused Errors when taking square root from negative values.
-    np.fill_diagonal(corr_mat.values, 1)
+    corr_mat[corr_mat > 1] = 1
     distance = ((1 - corr_mat.fillna(0)) / 2.0) ** 0.5
     silh = pd.Series(dtype='float64')
 

--- a/mlfinlab/tests/test_feature_clusters.py
+++ b/mlfinlab/tests/test_feature_clusters.py
@@ -23,14 +23,25 @@ class TestFeatureClusters(unittest.TestCase):
         Test get_feature_clusters arguments
         """
         #test for different dependence matrix
-
-        clustered_subsets = get_feature_clusters(self.X, dependence_metric='information_variation',
-                                                 distance_metric='angular', linkage_method='single',
-                                                 n_clusters=2)
+        #get ONC on codependence metrics (i.e. Variation of Infomation and Mutual Information Scores)
+        #here ONC will decide and develope the cluster from the given dependence_matric
+        onc_clusters_VI = get_feature_clusters(self.X, dependence_metric='information_variation',
+                                               distance_metric=None, linkage_method=None,
+                                               n_clusters=None)
+        onc_clusters_MI = get_feature_clusters(self.X, dependence_metric='mutual_information',
+                                               distance_metric=None, linkage_method=None,
+                                               n_clusters=None)
+        onc_clusters_DC = get_feature_clusters(self.X, dependence_metric='distance_correlation',
+                                               distance_metric=None, linkage_method=None,
+                                               n_clusters=None)
+        #hierarchical clustering for codependence metrics
+        h_clusters = get_feature_clusters(self.X, dependence_metric='information_variation',
+                                          distance_metric='angular', linkage_method='single',
+                                          n_clusters=2)
         #hierarchical auto clustering
-        clustered_subsets_ha = get_feature_clusters(self.X, dependence_metric='linear',
-                                                    distance_metric='angular', linkage_method='single',
-                                                    n_clusters=None, critical_threshold=0.2)
+        h_clusters_auto = get_feature_clusters(self.X, dependence_metric='linear',
+                                               distance_metric='angular', linkage_method='single',
+                                               n_clusters=None, critical_threshold=0.2)
         #test for optimal number of clusters and  _check_for_low_silhouette_scores
         #since this is done on test dataset so there will be no features with low silhouette score
         #so we will make a feature with some what lower silhouette score (near to zero) and set
@@ -43,10 +54,14 @@ class TestFeatureClusters(unittest.TestCase):
                                                           n_clusters=None, critical_threshold=0.2)
 
         #assertions
-        #output clusters must be 2
-        self.assertEqual(len(clustered_subsets), 2)
+        #codependence metric cluster using ONC
+        self.assertAlmostEqual(len(onc_clusters_VI), 7, delta=1)
+        self.assertAlmostEqual(len(onc_clusters_MI), 6, delta=1)
+        self.assertAlmostEqual(len(onc_clusters_DC), 6, delta=1)
+        #output clusters must be 2 since n_clusters was specified as 2
+        self.assertEqual(len(h_clusters), 2)
         #The ONC should detect somwhere around 5 clusters
-        self.assertAlmostEqual(len(clustered_subsets_ha), 5, delta=1)
+        self.assertAlmostEqual(len(h_clusters_auto), 5, delta=1)
         self.assertAlmostEqual(len(clustered_subsets_distance), 5, delta=1)
 
     def test_value_error_raise(self):


### PR DESCRIPTION
# Description

This PR changes feature clusters to use defined codependence to check for low silhouette scores. Previously Pearson's correlation was used for all codependence inputs.

It also fixes numerical errors in codependence matrices:
Fixes #405 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

The unit test was updated to test results for `information_variation`, `mutual_information`, `distance_correlation` codepencence inputs.

- [x] test_feature_clusters.py 

**Test Configuration**:
* Windows 10
* PyCharm

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
