### PR TITLE
Fix double de-noising bug

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -22,7 +22,7 @@ copyright = '2019, Hudson & Thames,'
 author = 'Hudson & Thames'
 
 # The full version, including alpha/beta/rc tags
-release = '0.12.0'
+release = '0.12.3'
 
 
 # -- General configuration ---------------------------------------------------

--- a/mlfinlab/portfolio_optimization/mean_variance.py
+++ b/mlfinlab/portfolio_optimization/mean_variance.py
@@ -182,7 +182,7 @@ class MeanVarianceOptimisation:
 
         print("Portfolio Return = %s" % self.portfolio_return)
         print("Portfolio Risk = %s" % self.portfolio_risk)
-        print("Portfolio Sharpe Ratio = %s" % self.portfolio_risk)
+        print("Portfolio Sharpe Ratio = %s" % self.portfolio_sharpe_ratio)
 
     def plot_efficient_frontier(self, covariance, expected_asset_returns, min_return=0, max_return=0.4,
                                 risk_free_rate=0.05):

--- a/mlfinlab/portfolio_optimization/risk_estimators.py
+++ b/mlfinlab/portfolio_optimization/risk_estimators.py
@@ -344,7 +344,7 @@ class RiskEstimators:
 
         # Detone the correlation matrix if needed
         if detone:
-            corr = self._detoned_corr(corr, eigenval, eigenvec, num_facts, market_component)
+            corr = self._detoned_corr(corr, eigenval, eigenvec, market_component)
 
         # Calculating the covariance matrix from the de-noised correlation matrix
         cov_denoised = self.corr_to_cov(corr, np.diag(cov) ** (1 / 2))
@@ -618,7 +618,7 @@ class RiskEstimators:
 
         return corr
 
-    def _detoned_corr(self, corr, eigenvalues, eigenvectors, num_facts, market_component=1):
+    def _detoned_corr(self, corr, eigenvalues, eigenvectors, market_component=1):
         """
         De-tones the correlation matrix by removing the market component.
 
@@ -629,13 +629,9 @@ class RiskEstimators:
         :param corr: (np.array) Correlation matrix to detone.
         :param eigenvalues: (np.array) Matrix with eigenvalues on the main diagonal.
         :param eigenvectors: (float) Eigenvectors array.
-        :param num_facts: (float) Threshold for eigenvalues to be fixed.
         :param market_component: (int) Number of fist eigevectors related to a market component. (1 by default)
         :return: (np.array) De-toned correlation matrix.
         """
-
-        # Getting the de-noised correlation matrix
-        corr = self._denoised_corr(eigenvalues, eigenvectors, num_facts)
 
         # Getting the eigenvalues and eigenvectors related to market component
         eigenvalues_mark = eigenvalues[:market_component, :market_component]

--- a/mlfinlab/portfolio_optimization/risk_estimators.py
+++ b/mlfinlab/portfolio_optimization/risk_estimators.py
@@ -344,7 +344,7 @@ class RiskEstimators:
 
         # Detone the correlation matrix if needed
         if detone:
-            corr = self._detoned_corr(corr, eigenval, eigenvec, market_component)
+            corr = self._detoned_corr(corr, market_component)
 
         # Calculating the covariance matrix from the de-noised correlation matrix
         cov_denoised = self.corr_to_cov(corr, np.diag(cov) ** (1 / 2))
@@ -618,7 +618,7 @@ class RiskEstimators:
 
         return corr
 
-    def _detoned_corr(self, corr, eigenvalues, eigenvectors, market_component=1):
+    def _detoned_corr(self, corr, market_component=1):
         """
         De-tones the correlation matrix by removing the market component.
 
@@ -627,11 +627,12 @@ class RiskEstimators:
         eigenvectors related to a market component.
 
         :param corr: (np.array) Correlation matrix to detone.
-        :param eigenvalues: (np.array) Matrix with eigenvalues on the main diagonal.
-        :param eigenvectors: (float) Eigenvectors array.
         :param market_component: (int) Number of fist eigevectors related to a market component. (1 by default)
         :return: (np.array) De-toned correlation matrix.
         """
+
+        # Calculating eigenvalues and eigenvectors of the de-noised matrix
+        eigenvalues, eigenvectors = self._get_pca(corr)
 
         # Getting the eigenvalues and eigenvectors related to market component
         eigenvalues_mark = eigenvalues[:market_component, :market_component]

--- a/mlfinlab/tests/test_mean_variance.py
+++ b/mlfinlab/tests/test_mean_variance.py
@@ -511,12 +511,13 @@ class TestMVO(unittest.TestCase):
 
         mvo = MeanVarianceOptimisation()
         mvo.allocate(asset_prices=self.data)
+        print(mvo.get_portfolio_metrics())
         with patch('sys.stdout', new=StringIO()) as fake_out:
             mvo.get_portfolio_metrics()
             output = fake_out.getvalue().strip()
             self.assertTrue('Portfolio Return = 0.017362404155484328' in output)
             self.assertTrue('Portfolio Risk = 9.385801639141577e-06' in output)
-            self.assertTrue('Portfolio Sharpe Ratio = 9.385801639141577e-06' in output)
+            self.assertTrue('Portfolio Sharpe Ratio = -4.125045816381284' in output)
 
     def test_custom_objective_function(self):
         """

--- a/mlfinlab/tests/test_mean_variance.py
+++ b/mlfinlab/tests/test_mean_variance.py
@@ -511,13 +511,12 @@ class TestMVO(unittest.TestCase):
 
         mvo = MeanVarianceOptimisation()
         mvo.allocate(asset_prices=self.data)
-        print(mvo.get_portfolio_metrics())
         with patch('sys.stdout', new=StringIO()) as fake_out:
             mvo.get_portfolio_metrics()
             output = fake_out.getvalue().strip()
             self.assertTrue('Portfolio Return = 0.017362404155484328' in output)
             self.assertTrue('Portfolio Risk = 9.385801639141577e-06' in output)
-            self.assertTrue('Portfolio Sharpe Ratio = -4.125045816381284' in output)
+            self.assertTrue('Portfolio Sharpe Ratio = -4.125045816381286' in output)
 
     def test_custom_objective_function(self):
         """

--- a/mlfinlab/tests/test_risk_estimators.py
+++ b/mlfinlab/tests/test_risk_estimators.py
@@ -276,7 +276,7 @@ class TestRiskEstimators(unittest.TestCase):
                                   [0.39391882, 0.6897809, 1]])
 
         # Finding the de-toned correlation matrix
-        corr_matrix = risk_estimators._detoned_corr(corr, eigenvalues, eigenvectors)
+        corr_matrix = risk_estimators._detoned_corr(corr)
 
         # Testing if the de-toned correlation matrix is right
         np.testing.assert_almost_equal(corr_matrix, expected_corr, decimal=4)
@@ -311,9 +311,9 @@ class TestRiskEstimators(unittest.TestCase):
                                      [0.0057, 0.04, -0.0106],
                                      [-0.0028, -0.0106, 0.01]])
 
-        expected_cov_detoned = np.array([[0.01, -0.00672445, 0.00336222],
-                                         [-0.00672445, 0.04, 0.01769514],
-                                         [0.00336222, 0.01769514, 0.01]])
+        expected_cov_detoned = np.array([[0.01, -0.0094, 0.0047],
+                                         [-0.0094, 0.04, 0.0111],
+                                         [0.0047, 0.0111, 0.01]])
 
         # Finding the de-noised covariance matrix
         cov_matrix_denoised = risk_estimators.denoise_covariance(cov_matrix, tn_relation, denoise_method, detone,

--- a/mlfinlab/tests/test_risk_estimators.py
+++ b/mlfinlab/tests/test_risk_estimators.py
@@ -257,6 +257,8 @@ class TestRiskEstimators(unittest.TestCase):
                          [0.1, 1, -0.3],
                          [-0.1, -0.3, 1]])
 
+        e_val, e_vec = np.linalg.eigh(corr)
+
         # Eigenvalues and eigenvectors to use
         eigenvalues = np.array([[1.3562, 0, 0],
                                 [0, 0.9438, 0],
@@ -265,13 +267,16 @@ class TestRiskEstimators(unittest.TestCase):
                                  [-6.57192300e-01, 2.60956474e-01, 7.07106781e-01],
                                  [6.57192300e-01, -2.60956474e-01, 7.07106781e-01]])
 
+        np.testing.assert_almost_equal(np.diag(np.flip(e_val)), eigenvalues, decimal=4)
+        np.testing.assert_almost_equal(np.fliplr(e_vec), eigenvectors, decimal=4)
+
         # Expected correlation matrix
-        expected_corr = np.array([[1, -0.33622026, 0.33622026],
-                                  [-0.33622026, 1, 0.88478197],
-                                  [0.33622026, 0.88478197, 1]])
+        expected_corr = np.array([[1, -0.39391882, 0.39391882],
+                                  [-0.39391882, 1, 0.6897809],
+                                  [0.39391882, 0.6897809, 1]])
 
         # Finding the de-toned correlation matrix
-        corr_matrix = risk_estimators._detoned_corr(corr, eigenvalues, eigenvectors, 1)
+        corr_matrix = risk_estimators._detoned_corr(corr, eigenvalues, eigenvectors)
 
         # Testing if the de-toned correlation matrix is right
         np.testing.assert_almost_equal(corr_matrix, expected_corr, decimal=4)

--- a/mlfinlab/tests/test_risk_estimators.py
+++ b/mlfinlab/tests/test_risk_estimators.py
@@ -257,19 +257,6 @@ class TestRiskEstimators(unittest.TestCase):
                          [0.1, 1, -0.3],
                          [-0.1, -0.3, 1]])
 
-        e_val, e_vec = np.linalg.eigh(corr)
-
-        # Eigenvalues and eigenvectors to use
-        eigenvalues = np.array([[1.3562, 0, 0],
-                                [0, 0.9438, 0],
-                                [0, 0, 0.7]])
-        eigenvectors = np.array([[-3.69048184e-01, -9.29410263e-01, 1.10397126e-16],
-                                 [-6.57192300e-01, 2.60956474e-01, 7.07106781e-01],
-                                 [6.57192300e-01, -2.60956474e-01, 7.07106781e-01]])
-
-        np.testing.assert_almost_equal(np.diag(np.flip(e_val)), eigenvalues, decimal=4)
-        np.testing.assert_almost_equal(np.fliplr(e_vec), eigenvectors, decimal=4)
-
         # Expected correlation matrix
         expected_corr = np.array([[1, -0.39391882, 0.39391882],
                                   [-0.39391882, 1, 0.6897809],

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = mlfinlab
-version = 0.12.0
+version = 0.12.3
 author = Hudson and Thames Quantitative Research
 author_email = research@hudsonthames.org
 licence = All Rights Reserved


### PR DESCRIPTION
# Description

This PR fixes the bug in the de-noising function. When one would de-tone the correlation/covariance matrix, it would be de-noised again.

This PR includes commits from PR #424, as the Travis CI- Branch wasn't building.

This PR also fixes #427 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

This PR changes one unit test form the following file:

- [x] python test_risk_estimator

**Test Configuration**:
* Windows 10
* PyCharm

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
