### PR TITLE
Handle NaNs in input data

### DIFF
--- a/mlfinlab/portfolio_optimization/hrp.py
+++ b/mlfinlab/portfolio_optimization/hrp.py
@@ -64,6 +64,8 @@ class HierarchicalRiskParity:
                 asset_names = asset_prices.columns
             elif asset_returns is not None and isinstance(asset_returns, pd.DataFrame):
                 asset_names = asset_returns.columns
+            elif covariance_matrix is not None and isinstance(covariance_matrix, pd.DataFrame):
+                asset_names = covariance_matrix.columns
             else:
                 raise ValueError("Please provide a list of asset names")
 
@@ -76,12 +78,17 @@ class HierarchicalRiskParity:
         if covariance_matrix is None:
             covariance_matrix = asset_returns.cov()
         covariance_matrix = pd.DataFrame(covariance_matrix, index=asset_names, columns=asset_names)
+        covariance_matrix = self._nan_and_diagonal_checks(covariance_matrix, nan_fill_value=0)
 
-        # Calculate correlation and distance from covariance matrix
+        # Calculate correlation matrix from the covariance
         correlation_matrix = self.risk_estimator.cov_to_corr(covariance_matrix)
+        correlation_matrix = self._nan_and_diagonal_checks(correlation_matrix, nan_fill_value=0, diagonal_fill_value=1)
+
+        # Calculate the distance matrix or use a custom one
         if distance_matrix is None:
             distance_matrix = np.sqrt((1 - correlation_matrix).round(5) / 2)
         distance_matrix = pd.DataFrame(distance_matrix, index=asset_names, columns=asset_names)
+        distance_matrix = self._nan_and_diagonal_checks(distance_matrix, nan_fill_value=0, diagonal_fill_value=0)
 
         # Step-1: Tree Clustering
         self.clusters = self._tree_clustering(distance=distance_matrix, method=linkage)
@@ -112,6 +119,21 @@ class HierarchicalRiskParity:
 
         dendrogram_plot = dendrogram(self.clusters, labels=assets)
         return dendrogram_plot
+
+    def _nan_and_diagonal_checks(self, matrix, nan_fill_value=0, diagonal_fill_value=None):
+        """
+        Check for any NaN values in the matrix and discrepancies in the diagonal values.
+
+        :param matrix: (pd.DataFrame) The matrix which needs to be processed.
+        :param nan_fill_value: (float) Replacement value for NaNs
+        :param diagonal_fill_value: (float) The values to use for filling the diagonal.
+        :return: (pd.DataFrame) Processed matrix.
+        """
+
+        matrix = matrix.fillna(nan_fill_value)
+        if diagonal_fill_value:
+            np.fill_diagonal(matrix.values, val=diagonal_fill_value)
+        return matrix
 
     @staticmethod
     def _tree_clustering(distance, method='single'):
@@ -190,6 +212,7 @@ class HierarchicalRiskParity:
 
         inv_diag = 1 / np.diag(covariance.values)
         parity_w = inv_diag * (1 / np.sum(inv_diag))
+        parity_w = np.nan_to_num(parity_w)
         return parity_w
 
     def _get_cluster_variance(self, covariance, cluster_indices):
@@ -230,6 +253,11 @@ class HierarchicalRiskParity:
                 left_cluster_variance = self._get_cluster_variance(covariance, left_cluster)
                 right_cluster_variance = self._get_cluster_variance(covariance, right_cluster)
                 alloc_factor = 1 - left_cluster_variance / (left_cluster_variance + right_cluster_variance)
+
+                # If for some reason the allocation factor is not calculated properly due to NaNs in the data, then split
+                # the allocation equally between the two clusters.
+                if np.isnan(alloc_factor):
+                    alloc_factor = 0.5
 
                 # Assign weights to each sub-cluster
                 self.weights[left_cluster] *= alloc_factor

--- a/mlfinlab/portfolio_optimization/hrp.py
+++ b/mlfinlab/portfolio_optimization/hrp.py
@@ -120,7 +120,8 @@ class HierarchicalRiskParity:
         dendrogram_plot = dendrogram(self.clusters, labels=assets)
         return dendrogram_plot
 
-    def _nan_and_diagonal_checks(self, matrix, nan_fill_value=0, diagonal_fill_value=None):
+    @staticmethod
+    def _nan_and_diagonal_checks(matrix, nan_fill_value=0, diagonal_fill_value=None):
         """
         Check for any NaN values in the matrix and discrepancies in the diagonal values.
 

--- a/mlfinlab/tests/test_hrp.py
+++ b/mlfinlab/tests/test_hrp.py
@@ -161,7 +161,6 @@ class TestHRP(unittest.TestCase):
         assert len(weights) == self.data.shape[1]
         np.testing.assert_almost_equal(np.sum(weights), 1)
 
-
     def test_hrp_with_linkage_method(self):
         """
         Test HRP when passing a custom linkage method.

--- a/mlfinlab/tests/test_hrp.py
+++ b/mlfinlab/tests/test_hrp.py
@@ -8,6 +8,7 @@ import numpy as np
 import pandas as pd
 from mlfinlab.portfolio_optimization.hrp import HierarchicalRiskParity
 from mlfinlab.portfolio_optimization.returns_estimators import ReturnsEstimators
+from mlfinlab.portfolio_optimization.risk_estimators import RiskEstimators
 
 
 class TestHRP(unittest.TestCase):
@@ -136,11 +137,7 @@ class TestHRP(unittest.TestCase):
         hrp = HierarchicalRiskParity()
         returns = ReturnsEstimators().calculate_returns(asset_prices=self.data)
         covariance = returns.cov()
-        d_matrix = np.zeros_like(covariance)
-        diagnoal_sqrt = np.sqrt(np.diag(covariance))
-        np.fill_diagonal(d_matrix, diagnoal_sqrt)
-        d_inv = np.linalg.inv(d_matrix)
-        corr = np.dot(np.dot(d_inv, covariance), d_inv)
+        corr = RiskEstimators.cov_to_corr(covariance)
         corr = pd.DataFrame(corr, index=covariance.columns, columns=covariance.columns)
         distance_matrix = np.sqrt((1 - corr).round(5) / 2)
         hrp.allocate(asset_names=self.data.columns, covariance_matrix=covariance, distance_matrix=distance_matrix)
@@ -148,6 +145,22 @@ class TestHRP(unittest.TestCase):
         self.assertTrue((weights >= 0).all())
         self.assertTrue(len(weights) == self.data.shape[1])
         self.assertAlmostEqual(np.sum(weights), 1)
+
+    def test_hrp_with_nan_inputs(self):
+        """
+        Test HRP with NaN inputs
+        """
+
+        hrp = HierarchicalRiskParity()
+        returns = ReturnsEstimators().calculate_returns(asset_prices=self.data)
+        covariance = returns.cov()
+        covariance *= np.nan
+        hrp.allocate(covariance_matrix=covariance)
+        weights = hrp.weights.values[0]
+        assert (weights >= 0).all()
+        assert len(weights) == self.data.shape[1]
+        np.testing.assert_almost_equal(np.sum(weights), 1)
+
 
     def test_hrp_with_linkage_method(self):
         """


### PR DESCRIPTION
Currently, if there are NaNs in the covariance, correlation or the distance matrix, the HRP algorithm breaks down. This PR fixes this issue and adds code to handle NaNs in the data.