### PR TITLE
Handle NaNs in input data (Quantopian Version)

### DIFF
--- a/mlfinlab/portfolio_optimization/hrp.py
+++ b/mlfinlab/portfolio_optimization/hrp.py
@@ -119,7 +119,8 @@ class HierarchicalRiskParity:
         dendrogram_plot = dendrogram(self.clusters, labels=assets)
         return dendrogram_plot
 
-    def _nan_and_diagonal_checks(self, matrix, nan_fill_value=0, diagonal_fill_value=None):
+    @staticmethod
+    def _nan_and_diagonal_checks(matrix, nan_fill_value=0, diagonal_fill_value=None):
         """
         Check for any NaN values in the matrix and discrepancies in the diagonal values.
         :param matrix: (pd.DataFrame) The matrix which needs to be processed.


### PR DESCRIPTION
Currently, if there are NaNs in the covariance, correlation or the distance matrix, the HRP algorithm breaks down. This PR fixes this issue and adds code to handle NaNs in the data.

This will be merged in the Quantopian branch for QP's platform.