### PR TITLE
Fixing 2 typos in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,21 +14,21 @@
 ![pylint Score](https://mperlet.github.io/pybadge/badges/10.svg)
 [![Documentation Status](https://readthedocs.org/projects/mlfinlab/badge/?version=latest)](https://mlfinlab.readthedocs.io/en/latest/?badge=latest)
 
-MlFinlab is a python package which helps portfolio managers and traders who want to leverage the power of machine learning by providing reproducible, interpretable, and easy to use tools. 
-Adding MlFinLab to your companies pipeline is like adding a department of PhD researchers to your team.
+MlFinlab is a python package which helps portfolio managers and traders who want to leverage the power of machine learning by providing reproducible, interpretable, and easy to use tools.
+Adding MlFinLab to your company's pipeline is like adding a department of PhD researchers to your team.
 
 > **pip install mlfinlab**
 
 For a detailed installation guide for MacOS, Linux, and Windows please visit [this link](https://mlfinlab.readthedocs.io/en/latest/getting_started/installation.html).
 
-We source all of our implementations from the most elite and peer-reviewed journals. Including publications from: 
+We source all of our implementations from the most elite and peer-reviewed journals. Including publications from:
 1. [The Journal of Financial Data Science](https://jfds.pm-research.com/)
 2. [The Journal of Portfolio Management](https://jpm.pm-research.com/)
 3. [The Journal of Algorithmic Finance](http://www.algorithmicfinance.org/)
 4. [Cambridge University Press](https://www.cambridge.org/)
 
 We are making a big drive to include techniques from various authors, however the most dominant author would be Dr. Marcos Lopez de Prado ([QuantResearch.org](http://www.quantresearch.org/)).
-This package has its foundations in the two graduate level textbooks: 
+This package has its foundations in the two graduate level textbooks:
 1. [Advances in Financial Machine Learning](https://www.amazon.co.uk/Advances-Financial-Machine-Learning-Marcos/dp/1119482089)
 2. [Machine Learning for Asset Managers](https://www.cambridge.org/core/books/machine-learning-for-asset-managers/6D9211305EA2E425D33A9F38D0AE3545)
 
@@ -40,37 +40,37 @@ This package has its foundations in the two graduate level textbooks:
 
 ## Praise for MlFinLab
 > “Financial markets are complex systems like no other. Extracting signal from financial data requires specialized tools
-> that are distinct from those used in general machine learning. The MlFinLab package compiles important algorithms 
+> that are distinct from those used in general machine learning. The MlFinLab package compiles important algorithms
 >that every quant should know and use.”
 
 [Dr. Marcos Lopez de Prado](https://www.linkedin.com/in/lopezdeprado/), Co-founder and CIO at True Positive Technologies; Professor of Practice at Cornell University
 
 
->"Those who doubt open source libraries just need to look at the impact of Pandas, Scikit-learn, and the like. MIFinLab 
+>"Those who doubt open source libraries just need to look at the impact of Pandas, Scikit-learn, and the like. MIFinLab
 is doing to financial machine learning what Tensorflow and PyTorch are doing to deep learning."
 
 [Dr. Ernest Chan](https://www.linkedin.com/in/epchan/), Hedge Fund Manager at QTS & Author
 
->"For many decades, finance has relied on overly simplistic statistical techniques to identify patterns in data. 
->Machine learning promises to change that by allowing researchers to use modern nonlinear and highly dimensional 
->techniques. Yet, applying those machine learning algorithms to model financial problems is easier said than done: 
+>"For many decades, finance has relied on overly simplistic statistical techniques to identify patterns in data.
+>Machine learning promises to change that by allowing researchers to use modern nonlinear and highly dimensional
+>techniques. Yet, applying those machine learning algorithms to model financial problems is easier said than done:
 >finance is not a plug-and-play subject as it relates to machine learning.
 >
-> MlFinLab provides access to the latest cutting edges methods. MlFinLab is thus essential for quants who want to be 
+> MlFinLab provides access to the latest cutting edges methods. MlFinLab is thus essential for quants who want to be
 >ahead of the technology rather than being replaced by it."
 
 [Dr. Thomas Raffinot](https://www.linkedin.com/in/thomas-raffinot-b75734b/), Lead Data Scientist at AXA Investment Managers
 
 ## Documentation, Tutorials, Videos, and Source Code
 
-We lower barriers to entry for all users by providing extensive [documentation](https://mlfinlab.readthedocs.io/en/latest/) 
+We lower barriers to entry for all users by providing extensive [documentation](https://mlfinlab.readthedocs.io/en/latest/)
 and [tutorial notebooks](https://mlfinlab.readthedocs.io/en/latest/getting_started/research_notebooks.html), with code examples.
 
-We in the process of experimenting with various product ideas and models. Currently all of our tools which are private, 
+We in the process of experimenting with various product ideas and models. Currently all of our tools which are private,
 are available to the various [Patreon](https://www.patreon.com/HudsonThames) tiers.
 
 ## Who is Hudson & Thames?
-We are a private research group focused on implementing research based financial machine learning. We all work in 
+We are a private research group focused on implementing research based financial machine learning. We all work in
 virtual teams, spread across the world, primarily: New York, London, and Kyiv.
 
 * [Website](https://hudsonthames.org/)
@@ -109,17 +109,17 @@ virtual teams, spread across the world, primarily: New York, London, and Kyiv.
 ---
 
 ## Contact us
-We host a booming community of like minded data scientists and quants, join the 
-[Slack Channel](https://www.patreon.com/HudsonThames) now! Open to sponsors of our package. 
+We host a booming community of like minded data scientists and quants, join the
+[Slack Channel](https://www.patreon.com/HudsonThames) now! Open to sponsors of our package.
 
-The channel has the following benefits: 
+The channel has the following benefits:
 
 * Community of like minded individuals.
 * Ask questions about the package implementations and get community feedback.
 * Occasional presentations on topics within financial machine learning.
 * A papers channel where we share the papers which are freely available.
 * Access to members of our research group.
- 
+
 You can also email us at research@hudsonthames.org
 
 Looking forward to hearing from you!
@@ -132,4 +132,4 @@ This project is licensed under an all rights reserved licence.
 
 ## Note
 
-* This Public MlFinLab repo, houses our documentation and doesn't conatin the source code.
+* This Public MlFinLab repo, houses our documentation and doesn't contain the source code.


### PR DESCRIPTION
Hello,

This is very minor, but there were 2 typos in the project's Readme:

1. "Adding MlFinLab to your companies pipeline ..." should be "company's" rather than "companies"

2.  "...  doesn't conatin the source code." typo in the spelling of "contain"

So those 2 fixes have been made in this PR. Looks like my text editor automatically deleted all trailing white-spaces so that's why the diff seems much larger than it is. Feel free to close this PR and make the edits directly to the file if you prefer. 